### PR TITLE
feat: Dynaconf environment tiers + MLflow server backend (#110, #111)

### DIFF
--- a/configs/deployment/development.toml
+++ b/configs/deployment/development.toml
@@ -4,3 +4,4 @@ mlflow_tracking_uri = "http://localhost:5000"
 langfuse_enabled = true
 braintrust_enabled = false
 agent_provider = "ollama:qwen2.5-coder:14b"
+test_markers = "unit and not slow"

--- a/configs/deployment/production.toml
+++ b/configs/deployment/production.toml
@@ -1,5 +1,7 @@
 [production]
 debug = false
+mlflow_tracking_uri = "http://localhost:5000"
 langfuse_enabled = true
 braintrust_enabled = true
 agent_provider = "anthropic:claude-sonnet-4-6"
+test_markers = "unit and integration and e2e"

--- a/configs/deployment/settings.toml
+++ b/configs/deployment/settings.toml
@@ -42,3 +42,6 @@ drift_report_dir = "reports/drift"
 # Data
 dvc_remote = "minio"
 data_dir = "data"
+
+# Testing
+test_markers = "unit"

--- a/configs/deployment/staging.toml
+++ b/configs/deployment/staging.toml
@@ -1,5 +1,7 @@
 [staging]
 debug = false
+mlflow_tracking_uri = "http://localhost:5000"
 langfuse_enabled = true
 braintrust_enabled = true
 agent_provider = "anthropic:claude-sonnet-4-6"
+test_markers = "unit and integration and not slow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,6 +269,7 @@ markers = [
     "e2e: End-to-end pipeline tests",
     "slow: Tests that take >30s",
     "gpu: Tests requiring CUDA GPU",
+    "requires_mlflow_server: Tests requiring a running MLflow server (auto-skipped if unhealthy)",
 ]
 filterwarnings = [
     "error",

--- a/src/minivess/config/environment.py
+++ b/src/minivess/config/environment.py
@@ -1,0 +1,31 @@
+"""Environment detection utilities.
+
+Lightweight helpers for querying the active Dynaconf environment
+and MLflow backend type without importing heavy dependencies.
+"""
+
+from __future__ import annotations
+
+
+def is_mlflow_server_backend(tracking_uri: str) -> bool:
+    """Return ``True`` if the tracking URI points to an HTTP server.
+
+    Parameters
+    ----------
+    tracking_uri:
+        MLflow tracking URI string.
+    """
+    return tracking_uri.startswith(("http://", "https://"))
+
+
+def get_active_environment() -> str:
+    """Return the active Dynaconf environment name.
+
+    Falls back to ``"default"`` if Dynaconf is unavailable.
+    """
+    try:
+        from minivess.config.settings import get_settings
+
+        return str(getattr(get_settings(), "current_env", "default")).lower()
+    except Exception:
+        return "default"

--- a/src/minivess/config/settings.py
+++ b/src/minivess/config/settings.py
@@ -1,0 +1,59 @@
+"""Dynaconf settings singleton for deployment configuration.
+
+Provides a cached Dynaconf instance that reads from
+``configs/deployment/settings.toml`` with environment-based overrides
+(development.toml, staging.toml, production.toml).
+
+Usage::
+
+    from minivess.config.settings import get_settings
+
+    settings = get_settings()
+    print(settings.MLFLOW_TRACKING_URI)
+
+Environment switching via ``ENV_FOR_DYNACONF``::
+
+    ENV_FOR_DYNACONF=staging python -c "from minivess.config.settings import get_settings; print(get_settings().DEBUG)"
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+from dynaconf import Dynaconf
+
+_DEPLOYMENT_DIR = Path(__file__).resolve().parents[3] / "configs" / "deployment"
+
+
+@functools.lru_cache(maxsize=1)
+def get_settings() -> Dynaconf:
+    """Return the singleton Dynaconf settings instance.
+
+    Reads from ``configs/deployment/settings.toml`` (base) and
+    environment-specific overrides. Secrets from ``.secrets.toml``
+    (gitignored) are loaded when present.
+
+    Returns
+    -------
+    Dynaconf
+        Configured settings object.
+    """
+    return Dynaconf(
+        envvar_prefix="MINIVESS",
+        settings_files=[
+            str(_DEPLOYMENT_DIR / "settings.toml"),
+            str(_DEPLOYMENT_DIR / "development.toml"),
+            str(_DEPLOYMENT_DIR / "staging.toml"),
+            str(_DEPLOYMENT_DIR / "production.toml"),
+            str(_DEPLOYMENT_DIR / ".secrets.toml"),
+        ],
+        environments=True,
+        env_switcher="ENV_FOR_DYNACONF",
+        load_dotenv=False,
+    )
+
+
+def clear_settings_cache() -> None:
+    """Reset the settings singleton (for test isolation)."""
+    get_settings.cache_clear()

--- a/src/minivess/observability/health.py
+++ b/src/minivess/observability/health.py
@@ -1,0 +1,107 @@
+"""MLflow backend health checking.
+
+Provides a lightweight health check for the MLflow tracking backend,
+supporting both filesystem and server (HTTP) backends. Uses only
+stdlib ``urllib`` — no new dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import urlopen
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HealthCheckResult:
+    """Result of an MLflow backend health check.
+
+    Parameters
+    ----------
+    healthy:
+        Whether the backend is reachable and functional.
+    backend_type:
+        ``"filesystem"`` or ``"server"``.
+    message:
+        Human-readable status message.
+    uri:
+        The tracking URI that was checked.
+    """
+
+    healthy: bool
+    backend_type: str
+    message: str
+    uri: str
+
+
+def check_mlflow_health(tracking_uri: str | None = None) -> HealthCheckResult:
+    """Check health of the MLflow tracking backend.
+
+    Parameters
+    ----------
+    tracking_uri:
+        Tracking URI to check. If ``None``, resolves via
+        :func:`~minivess.observability.tracking.resolve_tracking_uri`.
+
+    Returns
+    -------
+    HealthCheckResult
+    """
+    if tracking_uri is None:
+        from minivess.observability.tracking import resolve_tracking_uri
+
+        tracking_uri = resolve_tracking_uri()
+
+    if tracking_uri.startswith(("http://", "https://")):
+        return _check_server_health(tracking_uri)
+    return _check_filesystem_health(tracking_uri)
+
+
+def _check_server_health(uri: str) -> HealthCheckResult:
+    """Ping an MLflow server via HTTP GET."""
+    health_url = uri.rstrip("/") + "/health"
+    try:
+        with urlopen(health_url, timeout=5) as response:  # noqa: S310
+            if response.status == 200:  # noqa: PLR2004
+                return HealthCheckResult(
+                    healthy=True,
+                    backend_type="server",
+                    message=f"MLflow server healthy at {uri}",
+                    uri=uri,
+                )
+            return HealthCheckResult(
+                healthy=False,
+                backend_type="server",
+                message=f"MLflow server returned status {response.status}",
+                uri=uri,
+            )
+    except Exception as exc:
+        return HealthCheckResult(
+            healthy=False,
+            backend_type="server",
+            message=f"MLflow server unreachable: {exc}",
+            uri=uri,
+        )
+
+
+def _check_filesystem_health(uri: str) -> HealthCheckResult:
+    """Check filesystem backend — create directory if missing."""
+    path = Path(uri)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return HealthCheckResult(
+            healthy=True,
+            backend_type="filesystem",
+            message=f"Filesystem backend ready at {path}",
+            uri=uri,
+        )
+    except OSError as exc:
+        return HealthCheckResult(
+            healthy=False,
+            backend_type="filesystem",
+            message=f"Cannot create filesystem backend: {exc}",
+            uri=uri,
+        )

--- a/src/minivess/observability/tracking.py
+++ b/src/minivess/observability/tracking.py
@@ -52,18 +52,26 @@ def extract_volume_ids(data_dicts: list[dict[str, str]]) -> list[str]:
     return sorted(ids)
 
 
-def resolve_tracking_uri(*, tracking_uri: str | None = None) -> str:
+def resolve_tracking_uri(
+    *,
+    tracking_uri: str | None = None,
+    use_dynaconf: bool = True,
+) -> str:
     """Resolve MLflow tracking URI from multiple sources.
 
     Priority order:
     1. Explicit ``tracking_uri`` parameter (highest)
     2. ``MLFLOW_TRACKING_URI`` environment variable
-    3. Default: ``"mlruns"`` (local file backend, no server needed)
+    3. Dynaconf settings (``configs/deployment/settings.toml``)
+    4. Default: ``"mlruns"`` (local file backend, safety net only)
 
     Parameters
     ----------
     tracking_uri:
         Explicit URI to use. If provided, returned as-is.
+    use_dynaconf:
+        Whether to consult Dynaconf settings. Set ``False`` to skip
+        the Dynaconf tier (useful for testing).
 
     Returns
     -------
@@ -74,6 +82,15 @@ def resolve_tracking_uri(*, tracking_uri: str | None = None) -> str:
     env_uri = os.environ.get("MLFLOW_TRACKING_URI")
     if env_uri:
         return env_uri
+    if use_dynaconf:
+        try:
+            from minivess.config.settings import get_settings
+
+            dynaconf_uri = getattr(get_settings(), "MLFLOW_TRACKING_URI", None)
+            if dynaconf_uri:
+                return str(dynaconf_uri)
+        except Exception:
+            logger.debug("Dynaconf unavailable, falling back to default")
     return str(_DEFAULT_TRACKING_URI)
 
 
@@ -359,22 +376,61 @@ class ExperimentTracker:
             if tmp_path is not None:
                 Path(tmp_path).unlink(missing_ok=True)
 
-    def log_dynaconf_config(self, settings_path: Path) -> None:
-        """Log Dynaconf settings.toml as artifact and extract key params.
+    def log_dynaconf_config(self, settings_path: Path | None = None) -> None:
+        """Log Dynaconf settings as params, tags, and artifact.
+
+        Uses the live Dynaconf singleton to read the active environment's
+        settings. Optionally logs the raw TOML file as artifact when
+        ``settings_path`` is provided.
 
         Parameters
         ----------
         settings_path:
-            Path to the Dynaconf ``settings.toml`` file.
+            Optional path to the Dynaconf ``settings.toml`` file.
+            Logged as artifact under ``config/`` when present.
         """
-        if not settings_path.exists():
-            logger.warning("Dynaconf settings not found: %s", settings_path)
-            return
+        # Log raw TOML file as artifact (backwards compat)
+        if settings_path is not None and settings_path.exists():
+            mlflow.log_artifact(str(settings_path), artifact_path="config")
 
-        # Log file as artifact
-        mlflow.log_artifact(str(settings_path), artifact_path="config")
+        # Log live settings from Dynaconf singleton
+        try:
+            from minivess.config.settings import get_settings
 
-        # Parse TOML and extract key params with cfg_ prefix
+            settings = get_settings()
+
+            # Log active environment as tag
+            current_env = getattr(settings, "current_env", "default")
+            mlflow.set_tag("cfg_environment", str(current_env).lower())
+
+            # Extract selected keys as params
+            cfg_keys = [
+                "project_name",
+                "data_dir",
+                "dvc_remote",
+                "mlflow_tracking_uri",
+            ]
+            cfg_params: dict[str, str] = {}
+            for key in cfg_keys:
+                value = getattr(settings, key.upper(), None)
+                if value is not None:
+                    cfg_params[f"cfg_{key}"] = str(value)
+
+            if cfg_params:
+                mlflow.log_params(cfg_params)
+            logger.info(
+                "Logged Dynaconf config (env=%s)",
+                current_env,
+            )
+        except Exception:
+            logger.warning("Failed to log Dynaconf config", exc_info=True)
+
+            # Fallback: parse TOML directly if Dynaconf unavailable
+            if settings_path is not None and settings_path.exists():
+                self._log_dynaconf_from_toml(settings_path)
+
+    def _log_dynaconf_from_toml(self, settings_path: Path) -> None:
+        """Fallback: parse raw TOML when Dynaconf is unavailable."""
         try:
             import tomllib
         except ImportError:
@@ -385,7 +441,6 @@ class ExperimentTracker:
             config = tomllib.loads(text)
             default = config.get("default", {})
 
-            # Extract selected keys as params
             cfg_keys = [
                 "project_name",
                 "data_dir",
@@ -399,7 +454,7 @@ class ExperimentTracker:
 
             if cfg_params:
                 mlflow.log_params(cfg_params)
-            logger.info("Logged Dynaconf config from %s", settings_path.name)
+            logger.info("Logged Dynaconf config from %s (fallback)", settings_path.name)
         except Exception:
             logger.warning("Failed to parse Dynaconf config", exc_info=True)
 

--- a/src/minivess/pipeline/preflight.py
+++ b/src/minivess/pipeline/preflight.py
@@ -508,6 +508,50 @@ def detect_environment() -> str:
     return "local"
 
 
+def check_mlflow_health() -> PreflightCheck:
+    """Check MLflow tracking backend health.
+
+    Uses the health module to validate the MLflow backend is reachable.
+    Returns WARNING (not CRITICAL) if the server is unreachable, since
+    training can proceed with local filesystem fallback.
+
+    Returns
+    -------
+    PreflightCheck
+    """
+    try:
+        from minivess.observability.health import (
+            check_mlflow_health as _health_check,
+        )
+
+        result = _health_check()
+        if result.healthy:
+            return PreflightCheck(
+                name="mlflow_health",
+                status=CheckStatus.PASS,
+                message=result.message,
+                details={
+                    "backend_type": result.backend_type,
+                    "uri": result.uri,
+                },
+            )
+        return PreflightCheck(
+            name="mlflow_health",
+            status=CheckStatus.WARNING,
+            message=result.message,
+            details={
+                "backend_type": result.backend_type,
+                "uri": result.uri,
+            },
+        )
+    except Exception as exc:
+        return PreflightCheck(
+            name="mlflow_health",
+            status=CheckStatus.WARNING,
+            message=f"MLflow health check failed: {exc}",
+        )
+
+
 def run_preflight(
     data_dir: Path,
     *,
@@ -545,6 +589,7 @@ def run_preflight(
         check_disk_space(path=disk_check_path, min_gb=min_disk_gb),
         check_swap(warn_gb=warn_swap_gb),
         check_data_exists(data_dir),
+        check_mlflow_health(),
     ]
 
     return PreflightResult(checks=checks, environment=environment)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -12,6 +10,37 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers", "real_data: requires real MiniVess dataset (not run in CI)"
     )
+    config.addinivalue_line(
+        "markers",
+        "requires_mlflow_server: Tests requiring a running MLflow server"
+        " (auto-skipped if unhealthy)",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Auto-skip tests marked with requires_mlflow_server when server is down."""
+    _mlflow_healthy: bool | None = None
+
+    for item in items:
+        if item.get_closest_marker("requires_mlflow_server") is not None:
+            # Lazy-evaluate health once per session
+            nonlocal_healthy = _mlflow_healthy
+            if nonlocal_healthy is None:
+                try:
+                    from minivess.observability.health import check_mlflow_health
+
+                    result = check_mlflow_health()
+                    nonlocal_healthy = result.healthy
+                except Exception:
+                    nonlocal_healthy = False
+                _mlflow_healthy = nonlocal_healthy
+
+            if not _mlflow_healthy:
+                item.add_marker(pytest.mark.skip(reason="MLflow server not reachable"))
+
 
 # Suppress warnings that occur during import of third-party libraries.
 # These must be set before the libraries are imported, so pytest's

--- a/tests/v2/unit/test_dynaconf_environments.py
+++ b/tests/v2/unit/test_dynaconf_environments.py
@@ -1,0 +1,80 @@
+"""Unit tests for Dynaconf environment tiers (Task 2).
+
+Tests that all environments (default, development, staging, production)
+have correct settings, especially mlflow_tracking_uri and debug flags.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestDynaconfEnvironmentTiers:
+    """Test environment-specific overrides in Dynaconf TOML files."""
+
+    def test_default_env_mlflow_uri_is_http(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default env MLFLOW_TRACKING_URI should start with http://."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert settings.MLFLOW_TRACKING_URI.startswith("http://")
+
+    @pytest.mark.parametrize("env", ["development", "staging", "production"])
+    def test_all_envs_have_nonempty_mlflow_uri(
+        self, monkeypatch: pytest.MonkeyPatch, env: str
+    ) -> None:
+        """All environments should have a non-empty MLFLOW_TRACKING_URI."""
+        monkeypatch.setenv("ENV_FOR_DYNACONF", env)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert isinstance(settings.MLFLOW_TRACKING_URI, str)
+        assert len(settings.MLFLOW_TRACKING_URI) > 0
+
+    def test_staging_debug_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Staging environment DEBUG should be False."""
+        monkeypatch.setenv("ENV_FOR_DYNACONF", "staging")
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert settings.DEBUG is False
+
+    def test_development_debug_is_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Development environment DEBUG should be True."""
+        monkeypatch.setenv("ENV_FOR_DYNACONF", "development")
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert settings.DEBUG is True
+
+    @pytest.mark.parametrize("env", ["development", "staging", "production"])
+    def test_all_envs_share_same_server_uri(
+        self, monkeypatch: pytest.MonkeyPatch, env: str
+    ) -> None:
+        """All environments should use the same Docker server URI."""
+        monkeypatch.setenv("ENV_FOR_DYNACONF", env)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert settings.MLFLOW_TRACKING_URI == "http://localhost:5000"
+
+    @pytest.mark.parametrize("env", ["development", "staging", "production"])
+    def test_all_envs_have_test_markers(
+        self, monkeypatch: pytest.MonkeyPatch, env: str
+    ) -> None:
+        """All environments should have non-empty test_markers setting."""
+        monkeypatch.setenv("ENV_FOR_DYNACONF", env)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert isinstance(settings.TEST_MARKERS, str)
+        assert len(settings.TEST_MARKERS) > 0

--- a/tests/v2/unit/test_dynaconf_settings.py
+++ b/tests/v2/unit/test_dynaconf_settings.py
@@ -1,0 +1,103 @@
+"""Unit tests for Dynaconf settings singleton (Task 1).
+
+Tests the settings.py module which provides a cached Dynaconf instance
+that reads from configs/deployment/*.toml with environment-based overrides.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestDynaconfSettingsSingleton:
+    """Test get_settings() returns a properly configured Dynaconf instance."""
+
+    def test_get_settings_returns_dynaconf_instance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_settings() should return a Dynaconf instance."""
+        from dynaconf import Dynaconf
+
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert isinstance(settings, Dynaconf)
+
+    def test_project_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Settings should contain PROJECT_NAME from settings.toml [default]."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert settings.PROJECT_NAME == "minivess-mlops-v2"
+
+    def test_mlflow_tracking_uri_is_nonempty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Settings should contain a non-empty MLFLOW_TRACKING_URI."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert isinstance(settings.MLFLOW_TRACKING_URI, str)
+        assert len(settings.MLFLOW_TRACKING_URI) > 0
+
+    def test_debug_exists_and_is_bool(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Settings should contain DEBUG as a boolean."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert isinstance(settings.DEBUG, bool)
+
+    def test_singleton_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two calls to get_settings() should return the exact same object."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        s1 = get_settings()
+        s2 = get_settings()
+        assert s1 is s2
+
+    def test_staging_debug_is_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """In staging environment, DEBUG should be False."""
+        monkeypatch.setenv("ENV_FOR_DYNACONF", "staging")
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        settings = get_settings()
+        assert settings.DEBUG is False
+
+    def test_missing_secrets_toml_does_not_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing .secrets.toml should not raise an error."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        # If this raises, the test fails
+        settings = get_settings()
+        assert settings.PROJECT_NAME is not None
+
+    def test_clear_settings_cache_resets_singleton(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """clear_settings_cache() should reset so next call creates new object."""
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        from minivess.config.settings import clear_settings_cache, get_settings
+
+        clear_settings_cache()
+        s1 = get_settings()
+        clear_settings_cache()
+        s2 = get_settings()
+        assert s1 is not s2

--- a/tests/v2/unit/test_environment_markers.py
+++ b/tests/v2/unit/test_environment_markers.py
@@ -1,0 +1,60 @@
+"""Unit tests for environment-aware pytest markers (Task 6).
+
+Tests the requires_mlflow_server marker, environment utilities,
+and auto-skip behavior.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestRequiresMlflowServerMarker:
+    """Test that requires_mlflow_server marker is registered."""
+
+    def test_marker_is_registered(self, pytestconfig: pytest.Config) -> None:
+        """requires_mlflow_server marker should not trigger strict-markers warning."""
+        markers = pytestconfig.getini("markers")
+        marker_names = [m.split(":")[0].strip() for m in markers]
+        assert "requires_mlflow_server" in marker_names
+
+
+class TestEnvironmentUtilities:
+    """Test environment detection utilities."""
+
+    def test_is_mlflow_server_backend_http(self) -> None:
+        """http:// URIs should return True."""
+        from minivess.config.environment import is_mlflow_server_backend
+
+        assert is_mlflow_server_backend("http://localhost:5000") is True
+
+    def test_is_mlflow_server_backend_https(self) -> None:
+        """https:// URIs should return True."""
+        from minivess.config.environment import is_mlflow_server_backend
+
+        assert is_mlflow_server_backend("https://mlflow.example.com") is True
+
+    def test_is_mlflow_server_backend_filesystem(self) -> None:
+        """Filesystem URIs should return False."""
+        from minivess.config.environment import is_mlflow_server_backend
+
+        assert is_mlflow_server_backend("mlruns") is False
+
+    def test_get_active_environment_returns_string(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """get_active_environment() should return a string."""
+        from minivess.config.settings import clear_settings_cache
+
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        clear_settings_cache()
+
+        from minivess.config.environment import get_active_environment
+
+        env = get_active_environment()
+        assert isinstance(env, str)
+        assert len(env) > 0

--- a/tests/v2/unit/test_mlflow_health.py
+++ b/tests/v2/unit/test_mlflow_health.py
@@ -1,0 +1,131 @@
+"""Unit tests for MLflow backend health check (Task 5).
+
+Tests the health.py module which provides HealthCheckResult dataclass
+and check_mlflow_health() function for both filesystem and server backends.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestHealthCheckResult:
+    """Test HealthCheckResult dataclass."""
+
+    def test_dataclass_fields(self) -> None:
+        """HealthCheckResult should have healthy, backend_type, message, uri."""
+        from minivess.observability.health import HealthCheckResult
+
+        result = HealthCheckResult(
+            healthy=True,
+            backend_type="server",
+            message="OK",
+            uri="http://localhost:5000",
+        )
+        assert result.healthy is True
+        assert result.backend_type == "server"
+        assert result.message == "OK"
+        assert result.uri == "http://localhost:5000"
+
+    def test_dataclass_is_frozen(self) -> None:
+        """HealthCheckResult should be immutable."""
+        from minivess.observability.health import HealthCheckResult
+
+        result = HealthCheckResult(
+            healthy=True,
+            backend_type="filesystem",
+            message="OK",
+            uri="mlruns",
+        )
+        with pytest.raises(AttributeError):
+            result.healthy = False  # type: ignore[misc]
+
+
+class TestCheckMlflowHealth:
+    """Test check_mlflow_health() for server and filesystem backends."""
+
+    def test_filesystem_uri_creates_dir_if_missing(self, tmp_path: Path) -> None:
+        """Filesystem URI should create directory and return healthy."""
+        from minivess.observability.health import check_mlflow_health
+
+        mlruns_dir = tmp_path / "mlruns"
+        assert not mlruns_dir.exists()
+        result = check_mlflow_health(str(mlruns_dir))
+        assert result.healthy is True
+        assert result.backend_type == "filesystem"
+        assert mlruns_dir.exists()
+
+    def test_filesystem_uri_existing_dir_is_healthy(self, tmp_path: Path) -> None:
+        """Filesystem URI with existing directory should return healthy."""
+        from minivess.observability.health import check_mlflow_health
+
+        mlruns_dir = tmp_path / "mlruns"
+        mlruns_dir.mkdir()
+        result = check_mlflow_health(str(mlruns_dir))
+        assert result.healthy is True
+        assert result.backend_type == "filesystem"
+
+    def test_server_uri_mocked_200_is_healthy(self) -> None:
+        """Server URI returning 200 should be healthy."""
+        from minivess.observability.health import check_mlflow_health
+
+        with patch("minivess.observability.health.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            result = check_mlflow_health("http://localhost:5000")
+
+        assert result.healthy is True
+        assert result.backend_type == "server"
+
+    def test_server_uri_connection_error_is_unhealthy(self) -> None:
+        """Server URI with ConnectionError should be unhealthy."""
+        from urllib.error import URLError
+
+        from minivess.observability.health import check_mlflow_health
+
+        with patch(
+            "minivess.observability.health.urlopen",
+            side_effect=URLError("Connection refused"),
+        ):
+            result = check_mlflow_health("http://localhost:5000")
+
+        assert result.healthy is False
+        assert result.backend_type == "server"
+        assert "Connection refused" in result.message
+
+    def test_no_arg_uses_resolve_tracking_uri(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No-argument call should use resolve_tracking_uri() to get URI."""
+        from minivess.observability.health import check_mlflow_health
+
+        monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+        # With Dynaconf active, this resolves to http://localhost:5000
+        # Mock the server check to avoid actual connection
+        with patch("minivess.observability.health.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            result = check_mlflow_health()
+
+        assert result.uri  # Should have resolved to something
+
+    def test_preflight_includes_mlflow_health(self, tmp_path: Path) -> None:
+        """run_preflight should include an mlflow_health check."""
+        from minivess.pipeline.preflight import run_preflight
+
+        data_dir = tmp_path / "data" / "imagesTr"
+        data_dir.mkdir(parents=True)
+        (data_dir / "test.nii.gz").write_bytes(b"fake")
+        labels_dir = tmp_path / "data" / "labelsTr"
+        labels_dir.mkdir()
+        (labels_dir / "test.nii.gz").write_bytes(b"fake")
+
+        result = run_preflight(tmp_path / "data")
+        check_names = [c.name for c in result.checks]
+        assert "mlflow_health" in check_names

--- a/tests/v2/unit/test_observability.py
+++ b/tests/v2/unit/test_observability.py
@@ -75,14 +75,14 @@ def synthetic_loader() -> list[dict[str, torch.Tensor]]:
 class TestResolveTrackingUri:
     """Test tracking URI resolution priority: env → config → default."""
 
-    def test_default_is_mlruns(self) -> None:
-        """Without env var or explicit param, default should be 'mlruns'."""
+    def test_default_is_mlruns_without_dynaconf(self) -> None:
+        """With use_dynaconf=False and no env var, default should be 'mlruns'."""
         from minivess.observability.tracking import resolve_tracking_uri
 
         # Clear env var if set
         env_backup = os.environ.pop("MLFLOW_TRACKING_URI", None)
         try:
-            uri = resolve_tracking_uri()
+            uri = resolve_tracking_uri(use_dynaconf=False)
             assert uri == "mlruns"
         finally:
             if env_backup is not None:
@@ -109,6 +109,73 @@ class TestResolveTrackingUri:
 
         uri = resolve_tracking_uri(tracking_uri="http://custom:5000")
         assert uri == "http://custom:5000"
+
+    def test_dynaconf_tier_returns_server_uri(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With Dynaconf active and no env var, should return server URI."""
+        from minivess.config.settings import clear_settings_cache
+        from minivess.observability.tracking import resolve_tracking_uri
+
+        monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        clear_settings_cache()
+        uri = resolve_tracking_uri()
+        assert uri == "http://localhost:5000"
+
+    def test_env_var_overrides_dynaconf(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MLFLOW_TRACKING_URI env var should still override Dynaconf."""
+        from minivess.config.settings import clear_settings_cache
+        from minivess.observability.tracking import resolve_tracking_uri
+
+        monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://custom-server:9999")
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        clear_settings_cache()
+        uri = resolve_tracking_uri()
+        assert uri == "http://custom-server:9999"
+
+    def test_explicit_param_overrides_dynaconf(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit param should still win over Dynaconf."""
+        from minivess.config.settings import clear_settings_cache
+        from minivess.observability.tracking import resolve_tracking_uri
+
+        monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+        clear_settings_cache()
+        uri = resolve_tracking_uri(tracking_uri="http://explicit:1234")
+        assert uri == "http://explicit:1234"
+
+    def test_use_dynaconf_false_skips_dynaconf(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """use_dynaconf=False should skip Dynaconf tier and fall to default."""
+        from minivess.observability.tracking import resolve_tracking_uri
+
+        monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+        uri = resolve_tracking_uri(use_dynaconf=False)
+        assert uri == "mlruns"
+
+    def test_dynaconf_import_failure_graceful(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If Dynaconf import fails, should gracefully fall to default."""
+        import sys
+
+        from minivess.observability.tracking import resolve_tracking_uri
+
+        monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+        # Temporarily hide the settings module
+        original = sys.modules.get("minivess.config.settings")
+        sys.modules["minivess.config.settings"] = None  # type: ignore[assignment]
+        try:
+            uri = resolve_tracking_uri()
+            assert uri == "mlruns"
+        finally:
+            if original is not None:
+                sys.modules["minivess.config.settings"] = original
+            else:
+                sys.modules.pop("minivess.config.settings", None)
 
 
 class TestExperimentTrackerLocalBackend:
@@ -559,27 +626,116 @@ class TestExperimentTrackerLocalBackend:
         self,
         experiment_config: ExperimentConfig,
         local_tracking_uri: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """log_dynaconf_config should log key settings as params from live Dynaconf."""
+        from mlflow.tracking import MlflowClient
+
+        from minivess.config.settings import clear_settings_cache
+        from minivess.observability.tracking import ExperimentTracker
+
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        clear_settings_cache()
+
+        tracker = ExperimentTracker(experiment_config, tracking_uri=local_tracking_uri)
+        with tracker.start_run() as run_id:
+            tracker.log_dynaconf_config()
+
+        client = MlflowClient(tracking_uri=local_tracking_uri)
+        run = client.get_run(run_id)
+        assert run.data.params["cfg_project_name"] == "minivess-mlops-v2"
+        assert run.data.params["cfg_dvc_remote"] == "minio"
+
+    def test_log_dynaconf_config_logs_environment_tag(
+        self,
+        experiment_config: ExperimentConfig,
+        local_tracking_uri: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """log_dynaconf_config should log cfg_environment tag."""
+        from mlflow.tracking import MlflowClient
+
+        from minivess.config.settings import clear_settings_cache
+        from minivess.observability.tracking import ExperimentTracker
+
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        clear_settings_cache()
+
+        tracker = ExperimentTracker(experiment_config, tracking_uri=local_tracking_uri)
+        with tracker.start_run() as run_id:
+            tracker.log_dynaconf_config()
+
+        client = MlflowClient(tracking_uri=local_tracking_uri)
+        run = client.get_run(run_id)
+        assert "cfg_environment" in run.data.tags
+
+    def test_log_dynaconf_config_logs_live_params(
+        self,
+        experiment_config: ExperimentConfig,
+        local_tracking_uri: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """log_dynaconf_config should log cfg_mlflow_tracking_uri and cfg_project_name."""
+        from mlflow.tracking import MlflowClient
+
+        from minivess.config.settings import clear_settings_cache
+        from minivess.observability.tracking import ExperimentTracker
+
+        monkeypatch.delenv("ENV_FOR_DYNACONF", raising=False)
+        clear_settings_cache()
+
+        tracker = ExperimentTracker(experiment_config, tracking_uri=local_tracking_uri)
+        with tracker.start_run() as run_id:
+            tracker.log_dynaconf_config()
+
+        client = MlflowClient(tracking_uri=local_tracking_uri)
+        run = client.get_run(run_id)
+        assert "cfg_mlflow_tracking_uri" in run.data.params
+        assert "cfg_project_name" in run.data.params
+
+    def test_log_dynaconf_config_backwards_compat_path(
+        self,
+        experiment_config: ExperimentConfig,
+        local_tracking_uri: str,
         tmp_path: Path,
     ) -> None:
-        """log_dynaconf_config should log key settings as params."""
+        """log_dynaconf_config with settings_path still works (backwards compat)."""
+        from minivess.observability.tracking import ExperimentTracker
+
+        settings_path = tmp_path / "settings.toml"
+        settings_path.write_text(
+            '[default]\nproject_name = "test-compat"\n',
+            encoding="utf-8",
+        )
+        tracker = ExperimentTracker(experiment_config, tracking_uri=local_tracking_uri)
+        with tracker.start_run():
+            # Should not raise with optional path arg
+            tracker.log_dynaconf_config(settings_path)
+
+    def test_log_dynaconf_config_still_logs_artifact(
+        self,
+        experiment_config: ExperimentConfig,
+        local_tracking_uri: str,
+        tmp_path: Path,
+    ) -> None:
+        """log_dynaconf_config should still log TOML file as artifact."""
         from mlflow.tracking import MlflowClient
 
         from minivess.observability.tracking import ExperimentTracker
 
         settings_path = tmp_path / "settings.toml"
         settings_path.write_text(
-            '[default]\nproject_name = "test-project"\ndata_dir = "data"\ndvc_remote = "minio"\n',
+            '[default]\nproject_name = "test"\n',
             encoding="utf-8",
         )
-
         tracker = ExperimentTracker(experiment_config, tracking_uri=local_tracking_uri)
         with tracker.start_run() as run_id:
             tracker.log_dynaconf_config(settings_path)
 
         client = MlflowClient(tracking_uri=local_tracking_uri)
-        run = client.get_run(run_id)
-        assert run.data.params["cfg_project_name"] == "test-project"
-        assert run.data.params["cfg_dvc_remote"] == "minio"
+        artifacts = client.list_artifacts(run_id, path="config")
+        artifact_names = [a.path for a in artifacts]
+        assert any("settings" in name for name in artifact_names)
 
     def test_log_dvc_provenance_tags(
         self,


### PR DESCRIPTION
## Summary

- **Dynaconf settings singleton** (`get_settings()` / `clear_settings_cache()`) reading `configs/deployment/*.toml` with `environments=True` for tier-based overrides
- **4-tier URI resolution** in `resolve_tracking_uri()`: explicit param > env var > Dynaconf settings > `"mlruns"` fallback
- **MLflow backend health check** (`check_mlflow_health()`) using stdlib `urllib` — no new dependencies
- **Preflight integration** — `run_preflight()` now validates MLflow server reachability
- **`requires_mlflow_server` pytest marker** with auto-skip when server is unreachable
- **Rewritten `log_dynaconf_config()`** — uses live Dynaconf singleton instead of raw TOML parsing

All environments resolve to `http://localhost:5000` (Docker Compose MLflow server). Tiers differ on `debug`, `test_markers`, `agent_provider`, and `braintrust_enabled`.

### New files
| File | Purpose |
|------|---------|
| `src/minivess/config/settings.py` | Dynaconf singleton |
| `src/minivess/config/environment.py` | `is_mlflow_server_backend()`, `get_active_environment()` |
| `src/minivess/observability/health.py` | `HealthCheckResult` + `check_mlflow_health()` |

### ~33 new tests
- `test_dynaconf_settings.py` (8 tests)
- `test_dynaconf_environments.py` (12 tests)
- `test_mlflow_health.py` (8 tests)
- `test_environment_markers.py` (5 tests)
- 9 new tests in `test_observability.py`

Closes #110, closes #111

## Test plan

- [x] All 87 task-related tests pass locally
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, toml, secrets)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)