### PR TITLE
fix: Pre-commit mypy hook — local hook + validation overrides (#225)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,17 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+  - repo: local
     hooks:
       - id: mypy
-        additional_dependencies: [pydantic>=2.10]
-        args: [--ignore-missing-imports, --follow-imports=silent]
+        name: mypy
+        entry: uv run mypy
+        language: system
+        types: [python]
+        # Run on staged Python files only (uses project venv with all deps).
+        # mirrors-mypy ran in an isolated venv without torch/monai/pandera,
+        # causing false "Class cannot subclass Any" [misc] errors (#225).
+        pass_filenames: true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,6 +265,15 @@ warn_return_any = false
 warn_unused_ignores = false
 disable_error_code = ["type-arg"]
 
+# Validation: pandera DataFrameModel resolves to Any (incomplete stubs),
+# and @pa.check / @pa.dataframe_check decorators are untyped.
+# whylogs ResultSet also lacks stubs (get_columns → object).
+[[tool.mypy.overrides]]
+module = ["minivess.validation.*"]
+disallow_subclassing_any = false
+disallow_untyped_decorators = false
+warn_return_any = false
+
 # Archive: SAM2 reference code (archived, not part of active codebase)
 [[tool.mypy.overrides]]
 module = ["_archive.*"]

--- a/src/minivess/validation/profiling.py
+++ b/src/minivess/validation/profiling.py
@@ -31,7 +31,7 @@ class DatasetProfileView:
 
     def get_columns(self) -> list[str]:
         """Return the column names in the profile."""
-        return list(self._view.get_columns().keys())
+        return list(self._view.get_columns().keys())  # type: ignore[attr-defined]
 
     @property
     def raw(self) -> object:
@@ -82,8 +82,8 @@ def compare_profiles(
     drifted: list[str] = []
     summaries: dict[str, dict[str, float]] = {}
 
-    ref_cols = reference._view.get_columns()
-    cur_cols = current._view.get_columns()
+    ref_cols = reference._view.get_columns()  # type: ignore[attr-defined]
+    cur_cols = current._view.get_columns()  # type: ignore[attr-defined]
 
     for col_name in ref_cols:
         if col_name not in cur_cols:


### PR DESCRIPTION
## Summary

- Replace `mirrors-mypy` pre-commit hook with **local hook** using `uv run mypy` — runs in project venv with all dependencies (torch, monai, pandera) available
- Add mypy override for `minivess.validation.*` module: `disallow_subclassing_any = false`, `disallow_untyped_decorators = false` to handle pandera's incomplete stubs
- Add `type: ignore[attr-defined]` for 3 whylogs `get_columns()` calls in `profiling.py`
- Eliminates 9 pre-existing validation errors (381 → 372 total)

**Root cause:** `mirrors-mypy` ran in isolated venv with only `pydantic>=2.10` — no torch/monai/pandera stubs, so base classes resolved to `Any`, triggering `[misc]` errors.

Closes #225

## Test plan

- [x] `uv run mypy src/minivess/validation/` passes (0 errors)
- [x] `pre-commit run mypy` passes on staged validation files
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)