### PR TITLE
feat: SAM3 champion selection — model-agnostic verification (#221)

### DIFF
--- a/tests/v2/unit/test_champion_model_agnostic.py
+++ b/tests/v2/unit/test_champion_model_agnostic.py
@@ -1,15 +1,24 @@
-"""Tests for champion selection model-agnostic integration (SAM-15).
+"""Tests for champion selection model-agnostic integration (SAM-15, #221).
 
 Verifies that champion_tagger.py works correctly when model entries
 come from different model families (DynUNet, SAM3 variants).
+Includes filesystem tagging + discovery integration tests.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from minivess.pipeline.champion_tagger import (
+    clear_champion_tags_filesystem,
     rank_then_aggregate,
     select_champions,
+    write_champion_tags_filesystem,
 )
+from minivess.pipeline.deploy_champion_discovery import discover_champions
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _make_cross_model_entries() -> list[dict[str, object]]:
@@ -93,3 +102,147 @@ class TestChampionSelectionCrossModel:
         assert result["balanced"] == "dynunet"
         assert result["topology"] == "dynunet"  # best cldice
         assert result["overlap"] == "dynunet"  # best dsc
+
+
+def _setup_mlruns(
+    tmp_path: Path, experiment_id: str, runs: list[dict[str, str]]
+) -> Path:
+    """Create mock mlruns filesystem structure for multiple runs."""
+    mlruns = tmp_path / "mlruns"
+    for run in runs:
+        tags_dir = mlruns / experiment_id / run["run_id"] / "tags"
+        tags_dir.mkdir(parents=True)
+        # Write model family tag (as MLflow would)
+        (tags_dir / "model_family").write_text(run["model_family"], encoding="utf-8")
+    return mlruns
+
+
+class TestChampionFilesystemCrossModel:
+    """Filesystem tagging + discovery works with SAM3 and DynUNet runs."""
+
+    def test_write_tags_for_sam3_runs(self, tmp_path: Path) -> None:
+        """Champion tags written for SAM3 runs identical to DynUNet runs."""
+        runs = [
+            {
+                "run_id": "run_dynunet_0",
+                "model_family": "dynunet",
+                "loss_type": "dice_ce",
+            },
+            {
+                "run_id": "run_sam3_vanilla_0",
+                "model_family": "sam3_vanilla",
+                "loss_type": "dice_ce",
+            },
+            {
+                "run_id": "run_sam3_topolora_0",
+                "model_family": "sam3_topolora",
+                "loss_type": "cbdice_cldice",
+            },
+        ]
+        mlruns = _setup_mlruns(tmp_path, "1", runs)
+
+        # SAM3 vanilla wins on dice_ce
+        entries = [
+            {
+                "entry_type": "per_fold",
+                "model_name": "sam3_vanilla",
+                "loss_function": "dice_ce",
+                "fold_id": 0,
+                "primary_metric_value": 0.55,
+            },
+            {
+                "entry_type": "per_fold",
+                "model_name": "dynunet",
+                "loss_function": "dice_ce",
+                "fold_id": 0,
+                "primary_metric_value": 0.50,
+            },
+        ]
+        selection = select_champions(entries, primary_metric="dsc", maximize=True)
+        assert selection.best_single_fold is not None
+        assert selection.best_single_fold.model_name == "sam3_vanilla"
+
+        written = write_champion_tags_filesystem(
+            mlruns,
+            "1",
+            selection,
+            runs=runs,
+        )
+        # Both dice_ce runs get tagged (same loss function)
+        assert written > 0
+
+        # Verify champion tag files exist
+        for run in runs:
+            if run["loss_type"] == "dice_ce":
+                tag_file = (
+                    mlruns / "1" / run["run_id"] / "tags" / "champion_best_single_fold"
+                )
+                assert tag_file.exists()
+
+    def test_discover_champions_mixed_families(self, tmp_path: Path) -> None:
+        """discover_champions finds SAM3 champions alongside DynUNet."""
+        runs = [
+            {
+                "run_id": "dynunet_run",
+                "model_family": "dynunet",
+                "loss_type": "dice_ce",
+            },
+            {
+                "run_id": "sam3_run",
+                "model_family": "sam3_hybrid",
+                "loss_type": "cbdice_cldice",
+            },
+        ]
+        mlruns = _setup_mlruns(tmp_path, "1", runs)
+
+        # Manually write champion tags on the SAM3 run
+        tags_dir = mlruns / "1" / "sam3_run" / "tags"
+        (tags_dir / "champion_best_single_fold").write_text("true", encoding="utf-8")
+
+        champions = discover_champions(mlruns, "1")
+        assert len(champions) == 1
+        assert champions[0].run_id == "sam3_run"
+        assert champions[0].category == "overlap"  # best_single_fold → overlap
+
+    def test_clear_and_retag_across_families(self, tmp_path: Path) -> None:
+        """Clear old tags, retag with new SAM3 winner — no model family leakage."""
+        runs = [
+            {
+                "run_id": "old_dynunet",
+                "model_family": "dynunet",
+                "loss_type": "dice_ce",
+            },
+            {
+                "run_id": "new_sam3",
+                "model_family": "sam3_topolora",
+                "loss_type": "cbdice_cldice",
+            },
+        ]
+        mlruns = _setup_mlruns(tmp_path, "1", runs)
+
+        # Old DynUNet champion
+        old_tag = mlruns / "1" / "old_dynunet" / "tags" / "champion_best_cv_mean"
+        old_tag.write_text("true", encoding="utf-8")
+
+        # Clear old tags
+        cleared = clear_champion_tags_filesystem(mlruns, "1")
+        assert cleared == 1
+        assert not old_tag.exists()
+
+        # New SAM3 winner
+        entries = [
+            {
+                "entry_type": "cv_mean",
+                "model_name": "sam3_topolora",
+                "loss_function": "cbdice_cldice",
+                "fold_id": -1,
+                "primary_metric_value": 0.75,
+            },
+        ]
+        selection = select_champions(entries, primary_metric="dsc", maximize=True)
+        write_champion_tags_filesystem(mlruns, "1", selection, runs=runs)
+
+        # Discover should find SAM3 champion, not old DynUNet
+        champions = discover_champions(mlruns, "1")
+        assert len(champions) == 1
+        assert champions[0].run_id == "new_sam3"


### PR DESCRIPTION
## Summary

- Verified `champion_tagger.py` is **fully model-agnostic** — zero hardcoded model family logic
- Added 3 filesystem + discovery integration tests for SAM3 variants:
  - Write champion tags for SAM3 winners (same mechanism as DynUNet)
  - Discover champions from mixed DynUNet + SAM3 runs
  - Clear old DynUNet champion, retag with SAM3 winner — no model family leakage
- All 6 cross-model tests passing (3 existing selection + 3 new filesystem/discovery)

**Finding:** The champion system was already model-agnostic by design — selection is based on `loss_function` and `entry_type`, not `model_family`. These tests serve as regression protection.

Closes #221

## Test plan

- [x] `uv run pytest tests/v2/unit/test_champion_model_agnostic.py -x -q` — 6 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)