### PR TITLE
fix(orchestration): Prefect flow test fixes (#463, #470, #471)

### DIFF
--- a/src/minivess/orchestration/flows/analysis_flow.py
+++ b/src/minivess/orchestration/flows/analysis_flow.py
@@ -137,7 +137,7 @@ class _EnsembleInferenceWrapper(nn.Module):  # type: ignore[misc]
 
 def _discover_runs(
     eval_config: EvaluationConfig,
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
     *,
     tracking_uri: str | None = None,
 ) -> list[dict[str, Any]]:
@@ -150,7 +150,7 @@ def _discover_runs(
     ----------
     eval_config:
         Evaluation configuration.
-    model_config:
+    model_config_dict:
         Model architecture configuration.
     tracking_uri:
         Optional MLflow tracking URI override.
@@ -160,7 +160,7 @@ def _discover_runs(
     List of run info dicts, each with keys:
     ``run_id``, ``loss_type``, ``fold_id``, ``artifact_dir``, ``metrics``.
     """
-    builder = EnsembleBuilder(eval_config, model_config, tracking_uri=tracking_uri)
+    builder = EnsembleBuilder(eval_config, model_config_dict, tracking_uri=tracking_uri)
     result: list[dict[str, Any]] = builder.discover_training_runs()
     return result
 
@@ -272,7 +272,7 @@ def _extract_single_models_as_modules(
 
 def _log_single_model_safe(
     run: dict[str, Any],
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
     eval_config: EvaluationConfig,
 ) -> str | None:
     """Attempt to log a single model as MLflow pyfunc artifact.
@@ -300,7 +300,7 @@ def _log_single_model_safe(
         with mlflow.start_run(run_name=f"pyfunc_{name}"):
             log_single_model(
                 checkpoint_path=ckpt_path,
-                model_config_dict=model_config,
+                model_config_dict=model_config_dict,
             )
             active_run = mlflow.active_run()
             assert active_run is not None
@@ -316,7 +316,7 @@ def _log_single_model_safe(
 
 def _log_ensemble_model_safe(
     ensemble_spec: EnsembleSpec,
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
     eval_config: EvaluationConfig,
 ) -> str | None:
     """Attempt to log an ensemble model as MLflow pyfunc artifact.
@@ -333,7 +333,7 @@ def _log_ensemble_model_safe(
         with mlflow.start_run(run_name=f"pyfunc_{ensemble_spec.name}"):
             log_ensemble_model(
                 ensemble_spec=ensemble_spec,
-                model_config_dict=model_config,
+                model_config_dict=model_config_dict,
             )
             active_run = mlflow.active_run()
             assert active_run is not None
@@ -395,7 +395,7 @@ def _run_mlflow_eval_safe(
 @task(name="load-training-artifacts")
 def load_training_artifacts(
     eval_config: EvaluationConfig,
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
     *,
     tracking_uri: str | None = None,
 ) -> list[dict[str, Any]]:
@@ -407,7 +407,7 @@ def load_training_artifacts(
     ----------
     eval_config:
         Evaluation configuration with MLflow experiment name.
-    model_config:
+    model_config_dict:
         Model architecture configuration.
     tracking_uri:
         Optional MLflow tracking URI override.
@@ -419,7 +419,7 @@ def load_training_artifacts(
     log = get_run_logger()
     log.info("Loading training artifacts from MLflow...")
 
-    runs = _discover_runs(eval_config, model_config, tracking_uri=tracking_uri)
+    runs = _discover_runs(eval_config, model_config_dict, tracking_uri=tracking_uri)
 
     log.info(
         "Loaded %d training runs (%d unique losses)",
@@ -487,7 +487,7 @@ def discover_post_training_models(
 def build_ensembles(
     runs: list[dict[str, Any]],
     eval_config: EvaluationConfig,
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
 ) -> dict[str, EnsembleSpec]:
     """Build all configured ensemble strategies.
 
@@ -500,7 +500,7 @@ def build_ensembles(
         Pre-fetched run info dicts from :func:`load_training_artifacts`.
     eval_config:
         Evaluation configuration with ensemble strategy list.
-    model_config:
+    model_config_dict:
         Model architecture configuration.
 
     Returns
@@ -513,7 +513,7 @@ def build_ensembles(
         len(eval_config.ensemble_strategies),
     )
 
-    builder = EnsembleBuilder(eval_config, model_config)
+    builder = EnsembleBuilder(eval_config, model_config_dict)
     ensembles: dict[str, Any] = builder.build_all(runs)
 
     log.info(
@@ -529,7 +529,7 @@ def log_models_to_mlflow(
     runs: list[dict[str, Any]],
     ensembles: dict[str, EnsembleSpec],
     eval_config: EvaluationConfig,
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
 ) -> dict[str, str | None]:
     """Log single and ensemble models as MLflow pyfunc artifacts.
 
@@ -545,7 +545,7 @@ def log_models_to_mlflow(
         Built ensemble specifications.
     eval_config:
         Evaluation configuration.
-    model_config:
+    model_config_dict:
         Model architecture configuration.
 
     Returns
@@ -558,14 +558,14 @@ def log_models_to_mlflow(
     # Log individual fold models
     for run in runs:
         name = f"{run['loss_type']}_fold{run['fold_id']}"
-        uri = _log_single_model_safe(run, model_config, eval_config)
+        uri = _log_single_model_safe(run, model_config_dict, eval_config)
         model_uris[name] = uri
         if uri:
             log.info("Logged pyfunc model: %s -> %s", name, uri)
 
     # Log ensemble models
     for ens_name, spec in ensembles.items():
-        uri = _log_ensemble_model_safe(spec, model_config, eval_config)
+        uri = _log_ensemble_model_safe(spec, model_config_dict, eval_config)
         model_uris[ens_name] = uri
         if uri:
             log.info("Logged pyfunc ensemble: %s -> %s", ens_name, uri)
@@ -1455,7 +1455,7 @@ def _export_analysis_artifacts(
 @flow(name="analysis-flow", validate_parameters=False)
 def run_analysis_flow(
     eval_config: EvaluationConfig,
-    model_config: dict[str, Any],
+    model_config_dict: dict[str, Any],
     dataloaders_dict: HierarchicalDataLoaderDict,
     *,
     output_dir: Path | None = None,
@@ -1481,7 +1481,7 @@ def run_analysis_flow(
     ----------
     eval_config:
         :class:`EvaluationConfig` with metric and MLflow settings.
-    model_config:
+    model_config_dict:
         Model architecture configuration dict.
     dataloaders_dict:
         ``{dataset: {subset: DataLoader}}``.
@@ -1515,13 +1515,15 @@ def run_analysis_flow(
             )
 
     # Step 1: Load training artifacts
-    runs = load_training_artifacts(eval_config, model_config, tracking_uri=tracking_uri)
+    runs = load_training_artifacts(
+        eval_config, model_config_dict, tracking_uri=tracking_uri
+    )
 
     # Step 2: Build ensembles
-    ensembles = build_ensembles(runs, eval_config, model_config)
+    ensembles = build_ensembles(runs, eval_config, model_config_dict)
 
     # Step 3: Log models as MLflow pyfunc artifacts
-    model_uris = log_models_to_mlflow(runs, ensembles, eval_config, model_config)
+    model_uris = log_models_to_mlflow(runs, ensembles, eval_config, model_config_dict)
 
     # Step 4: Extract single-fold models from ensemble members
     single_models = _extract_single_models_as_modules(ensembles)

--- a/tests/v2/unit/test_acquisition_flow.py
+++ b/tests/v2/unit/test_acquisition_flow.py
@@ -1,12 +1,20 @@
 """Tests for Prefect Data Acquisition Flow (Flow 0).
 
 Phase 4, Tasks 4.1–4.3 of flow-data-acquisition-plan.md.
+
+All tests run with PREFECT_DISABLED=1 so the @flow/@task decorators are no-ops,
+exercising the pure-Python logic without a Prefect server.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-from unittest.mock import patch
+import os
+
+# Ensure Prefect is disabled before any minivess imports
+os.environ["PREFECT_DISABLED"] = "1"
+
+from typing import TYPE_CHECKING  # noqa: E402
+from unittest.mock import patch  # noqa: E402
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/v2/unit/test_analysis_flow.py
+++ b/tests/v2/unit/test_analysis_flow.py
@@ -335,6 +335,15 @@ class TestGenerateReport:
 class TestRunAnalysisFlow:
     """Tests for run_analysis_flow (the @flow)."""
 
+    @patch("minivess.orchestration.flows.analysis_flow.log_completion_safe")
+    @patch("minivess.orchestration.flows.analysis_flow.find_upstream_safely")
+    @patch("minivess.orchestration.flows.analysis_flow._export_analysis_artifacts")
+    @patch("minivess.orchestration.flows.analysis_flow.tag_champion_models")
+    @patch("minivess.orchestration.flows.analysis_flow.create_analysis_experiment")
+    @patch("minivess.orchestration.flows.analysis_flow.evaluate_with_mlflow")
+    @patch("minivess.orchestration.flows.analysis_flow.log_models_to_mlflow")
+    @patch("minivess.orchestration.flows.analysis_flow.discover_post_training_models")
+    @patch("minivess.orchestration.flows.analysis_flow._validate_analysis_env")
     @patch("minivess.orchestration.flows.analysis_flow.generate_report")
     @patch("minivess.orchestration.flows.analysis_flow.register_champion_task")
     @patch("minivess.orchestration.flows.analysis_flow.generate_comparison")
@@ -349,6 +358,15 @@ class TestRunAnalysisFlow:
         mock_compare: MagicMock,
         mock_register: MagicMock,
         mock_report: MagicMock,
+        mock_validate_env: MagicMock,
+        mock_discover: MagicMock,
+        mock_log_models: MagicMock,
+        mock_mlflow_eval: MagicMock,
+        mock_create_experiment: MagicMock,
+        mock_tag_champions: MagicMock,
+        mock_export_artifacts: MagicMock,
+        mock_find_upstream: MagicMock,
+        mock_log_completion: MagicMock,
     ) -> None:
         """run_analysis_flow returns dict with results, comparison, promotion, report."""
         from minivess.orchestration.flows.analysis_flow import (
@@ -365,6 +383,13 @@ class TestRunAnalysisFlow:
             "promotion_report": "# Report",
         }
         mock_report.return_value = "# Full Report"
+        mock_discover.return_value = []
+        mock_log_models.return_value = {}
+        mock_mlflow_eval.return_value = {}
+        mock_create_experiment.return_value = []
+        mock_tag_champions.return_value = {}
+        mock_export_artifacts.return_value = {}
+        mock_find_upstream.return_value = None
 
         config = _make_eval_config()
         model_config: dict[str, Any] = {"model_name": "DynUNet"}
@@ -382,6 +407,8 @@ class TestRunAnalysisFlow:
             "champion_tags",
             "artifact_paths",
             "post_training_models",
+            "mlflow_run_id",
+            "upstream_training_run_id",
         }
         assert set(result.keys()) == expected_keys
 
@@ -429,6 +456,15 @@ class TestEachTaskIndependentlyCallable:
 class TestAnalysisFlowWithMockData:
     """End-to-end test of the analysis flow with mocked dependencies."""
 
+    @patch("minivess.orchestration.flows.analysis_flow.log_completion_safe")
+    @patch("minivess.orchestration.flows.analysis_flow.find_upstream_safely")
+    @patch("minivess.orchestration.flows.analysis_flow._export_analysis_artifacts")
+    @patch("minivess.orchestration.flows.analysis_flow.tag_champion_models")
+    @patch("minivess.orchestration.flows.analysis_flow.create_analysis_experiment")
+    @patch("minivess.orchestration.flows.analysis_flow.evaluate_with_mlflow")
+    @patch("minivess.orchestration.flows.analysis_flow.log_models_to_mlflow")
+    @patch("minivess.orchestration.flows.analysis_flow.discover_post_training_models")
+    @patch("minivess.orchestration.flows.analysis_flow._validate_analysis_env")
     @patch("minivess.orchestration.flows.analysis_flow.ModelPromoter")
     @patch("minivess.orchestration.flows.analysis_flow.EnsembleBuilder")
     @patch("minivess.orchestration.flows.analysis_flow._discover_runs")
@@ -439,6 +475,15 @@ class TestAnalysisFlowWithMockData:
         mock_discover: MagicMock,
         mock_builder_cls: MagicMock,
         mock_promoter_cls: MagicMock,
+        mock_validate_env: MagicMock,
+        mock_discover_post: MagicMock,
+        mock_log_models: MagicMock,
+        mock_mlflow_eval: MagicMock,
+        mock_create_experiment: MagicMock,
+        mock_tag_champions: MagicMock,
+        mock_export_artifacts: MagicMock,
+        mock_find_upstream: MagicMock,
+        mock_log_completion: MagicMock,
     ) -> None:
         """Full flow executes all tasks and returns complete result."""
         from minivess.orchestration.flows.analysis_flow import (
@@ -471,6 +516,15 @@ class TestAnalysisFlowWithMockData:
         ]
         mock_promoter.generate_promotion_report.return_value = "# Promotion Report"
         mock_promoter_cls.return_value = mock_promoter
+
+        # Setup new mocks
+        mock_discover_post.return_value = []
+        mock_log_models.return_value = {}
+        mock_mlflow_eval.return_value = {}
+        mock_create_experiment.return_value = []
+        mock_tag_champions.return_value = {}
+        mock_export_artifacts.return_value = {}
+        mock_find_upstream.return_value = None
 
         config = _make_eval_config()
         model_config: dict[str, Any] = {"model_name": "DynUNet"}
@@ -676,6 +730,13 @@ class TestEvaluateWithMlflow:
 class TestUpdatedFlowWithMlflowSteps:
     """Tests for the updated run_analysis_flow with MLflow steps."""
 
+    @patch("minivess.orchestration.flows.analysis_flow.log_completion_safe")
+    @patch("minivess.orchestration.flows.analysis_flow.find_upstream_safely")
+    @patch("minivess.orchestration.flows.analysis_flow._export_analysis_artifacts")
+    @patch("minivess.orchestration.flows.analysis_flow.tag_champion_models")
+    @patch("minivess.orchestration.flows.analysis_flow.create_analysis_experiment")
+    @patch("minivess.orchestration.flows.analysis_flow.discover_post_training_models")
+    @patch("minivess.orchestration.flows.analysis_flow._validate_analysis_env")
     @patch("minivess.orchestration.flows.analysis_flow.generate_report")
     @patch("minivess.orchestration.flows.analysis_flow.register_champion_task")
     @patch("minivess.orchestration.flows.analysis_flow.generate_comparison")
@@ -694,6 +755,13 @@ class TestUpdatedFlowWithMlflowSteps:
         mock_compare: MagicMock,
         mock_register: MagicMock,
         mock_report: MagicMock,
+        mock_validate_env: MagicMock,
+        mock_discover: MagicMock,
+        mock_create_experiment: MagicMock,
+        mock_tag_champions: MagicMock,
+        mock_export_artifacts: MagicMock,
+        mock_find_upstream: MagicMock,
+        mock_log_completion: MagicMock,
     ) -> None:
         """Updated flow calls log_models_to_mlflow and evaluate_with_mlflow."""
         from minivess.orchestration.flows.analysis_flow import (
@@ -712,6 +780,11 @@ class TestUpdatedFlowWithMlflowSteps:
             "promotion_report": "# Report",
         }
         mock_report.return_value = "# Full Report"
+        mock_discover.return_value = []
+        mock_create_experiment.return_value = []
+        mock_tag_champions.return_value = {}
+        mock_export_artifacts.return_value = {}
+        mock_find_upstream.return_value = None
 
         config = _make_eval_config()
         model_config: dict[str, Any] = {"model_name": "DynUNet"}


### PR DESCRIPTION
## Summary

- **#463** — Rename `model_config` → `model_config_dict` in `analysis_flow.py` (7 functions: `_discover_runs`, `_log_single_model_safe`, `_log_ensemble_model_safe`, `load_training_artifacts`, `build_ensembles`, `log_models_to_mlflow`, `run_analysis_flow`). Avoids Pydantic v2 reserved name collision when Prefect's `@flow`/`@task` decorators create dynamic Pydantic models from function signatures.
- **#470** — Add 9 missing `@patch` decorators to 3 test methods in `test_analysis_flow.py` (`test_returns_dict_with_expected_keys`, `test_full_flow_with_mocks`, `test_flow_calls_mlflow_steps`). Mocks `_validate_analysis_env`, `discover_post_training_models`, `log_models_to_mlflow`, `evaluate_with_mlflow`, `create_analysis_experiment`, `tag_champion_models`, `_export_analysis_artifacts`, `find_upstream_safely`, `log_completion_safe`. Updates expected return keys to include `mlflow_run_id` and `upstream_training_run_id`.
- **#471** — Add `os.environ["PREFECT_DISABLED"] = "1"` to `test_acquisition_flow.py` before any `minivess.*` imports, matching the established pattern in `test_analysis_flow.py`. Prevents `RuntimeError: Failed to reach API at http://127.0.0.1:4200/api/`.

## Test plan

- [x] `tests/v2/unit/test_acquisition_flow.py` — 16 passed (was 1 failing)
- [x] `tests/v2/unit/test_analysis_flow.py` — 44 passed (was 3 failing)
- [x] `tests/unit/orchestration/test_explicit_upstream_params.py` — 8 passed (regression check)
- [x] `tests/v2/unit/test_ensemble_builder.py` — 37 passed (regression check for model_config rename)
- [x] All pre-commit hooks pass (ruff, ruff-format, mypy, test-collection-gate)

Closes #463, closes #470, closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)