### PR TITLE
fix: infrastructure hardening — Docker enforcement + pre-push gate (#424, #469)

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Install git hooks for the minivess-mlops repository.
+#
+# Usage:
+#   bash scripts/install-hooks.sh
+#
+# Installs a pre-push hook that runs scripts/pr_readiness_check.sh before
+# every `git push`. This prevents pushing code that fails lint, typecheck,
+# or unit tests.
+#
+# The hook is NOT a pre-commit hook (too slow) — it only runs on git push.
+# For pre-commit hooks see .pre-commit-config.yaml.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_DIR="$(git rev-parse --git-dir)/hooks"
+
+echo "Installing git hooks into ${HOOK_DIR}..."
+
+cat > "${HOOK_DIR}/pre-push" <<'HOOK'
+#!/usr/bin/env bash
+# Pre-push hook: run PR readiness check before pushing.
+# Installed by scripts/install-hooks.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo ""
+echo "======================================================"
+echo "  Pre-push gate: running PR readiness check..."
+echo "======================================================"
+echo ""
+
+bash "${REPO_ROOT}/scripts/pr_readiness_check.sh"
+HOOK
+
+chmod +x "${HOOK_DIR}/pre-push"
+
+echo ""
+echo "Pre-push hook installed at ${HOOK_DIR}/pre-push"
+echo "  -> Runs scripts/pr_readiness_check.sh on every 'git push'"
+echo ""
+echo "To bypass (emergencies only): git push --no-verify"

--- a/tests/unit/orchestration/test_prefect_decoupling_verification.py
+++ b/tests/unit/orchestration/test_prefect_decoupling_verification.py
@@ -1,0 +1,204 @@
+"""Prefect decoupling invariant verification tests.
+
+Encodes as permanent tests the decoupling properties verified by 4 subagents.
+Uses ast.parse() for Python analysis (CLAUDE.md Rule #16 — no regex).
+Uses yaml.safe_load() for docker-compose parsing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FLOWS_DIR = REPO_ROOT / "src" / "minivess" / "orchestration" / "flows"
+DOCKER_COMPOSE_FLOWS = REPO_ROOT / "deployment" / "docker-compose.flows.yml"
+
+# Core 6 flows that must always be present (per CLAUDE.md)
+CORE_FLOW_NAMES = {
+    "data_flow",
+    "train_flow",
+    "analysis_flow",
+    "deploy_flow",
+    "dashboard_flow",
+    "qa_flow",
+}
+
+# Docker service names corresponding to each core flow
+CORE_DOCKER_SERVICES = {
+    "data",
+    "train",
+    "analyze",
+    "deploy",
+    "dashboard",
+    "qa",
+}
+
+
+def _get_flow_files() -> list[Path]:
+    """Return all *_flow.py files in the flows directory."""
+    return sorted(FLOWS_DIR.glob("*_flow.py"))
+
+
+def _parse_flow(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _get_all_names_in_module(tree: ast.Module) -> set[str]:
+    """Collect all Name and Attribute values used in the module."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+def _get_function_defs(
+    tree: ast.Module,
+) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    ]
+
+
+def _get_imports(tree: ast.Module) -> list[tuple[str, str | None]]:
+    """Return (module, name_or_None) for all imports."""
+    imports: list[tuple[str, str | None]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append((alias.name, None))
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                imports.append((module, alias.name))
+    return imports
+
+
+class TestAllFlowsHaveDockerGate:
+    """Every *_flow.py must call _require_docker_context."""
+
+    @pytest.mark.parametrize("flow_file", _get_flow_files(), ids=lambda p: p.stem)
+    def test_all_flows_have_docker_gate(self, flow_file: Path) -> None:
+        tree = _parse_flow(flow_file)
+        names = _get_all_names_in_module(tree)
+        assert "_require_docker_context" in names, (
+            f"{flow_file.name} does not call _require_docker_context(). "
+            "Every flow must hard-gate against execution outside Docker. "
+            "See CLAUDE.md Rule #19 (STOP Protocol)."
+        )
+
+
+class TestNoCrossFlowImports:
+    """No *_flow.py should import from another *_flow.py.
+
+    Flows communicate ONLY through MLflow artifacts + Prefect artifacts.
+    Cross-flow Python imports create tight coupling that defeats decoupling.
+    Exception: dashboard_sections is a helper module (not a standalone flow).
+    """
+
+    @pytest.mark.parametrize("flow_file", _get_flow_files(), ids=lambda p: p.stem)
+    def test_no_cross_flow_imports(self, flow_file: Path) -> None:
+        tree = _parse_flow(flow_file)
+        imports = _get_imports(tree)
+        flow_stems = {f.stem for f in _get_flow_files() if f != flow_file}
+        # dashboard_sections is a helper module, not a standalone flow
+        flow_stems.discard("dashboard_sections")
+
+        violations = []
+        for module, _name in imports:
+            # Check if any part of the import path is another flow module
+            parts = module.split(".")
+            for part in parts:
+                if part in flow_stems:
+                    violations.append(f"  import from '{module}'")
+
+        assert not violations, (
+            f"{flow_file.name} has cross-flow imports:\n"
+            + "\n".join(violations)
+            + "\nFlows must communicate only through MLflow/Prefect artifacts."
+        )
+
+
+class TestAllFlowsHaveFlowNameConstant:
+    """Every flow must import a FLOW_NAME_* constant from orchestration.constants."""
+
+    @pytest.mark.parametrize("flow_file", _get_flow_files(), ids=lambda p: p.stem)
+    def test_all_flows_have_flow_name_constant(self, flow_file: Path) -> None:
+        tree = _parse_flow(flow_file)
+        imports = _get_imports(tree)
+        # Look for imports of FLOW_NAME_* from minivess.orchestration.constants
+        flow_name_imports = [
+            (m, n)
+            for m, n in imports
+            if m == "minivess.orchestration.constants"
+            and n is not None
+            and n.startswith("FLOW_NAME")
+        ]
+        assert flow_name_imports, (
+            f"{flow_file.name} does not import a FLOW_NAME_* constant from "
+            "minivess.orchestration.constants. Every flow must declare its canonical "
+            "name via the shared constants module so Prefect deployments are "
+            "consistently referenced. Add: "
+            "from minivess.orchestration.constants import FLOW_NAME_<FLOWNAME>"
+        )
+
+
+class TestNoTmpInFlowFiles:
+    """/tmp and tempfile are banned in flow files (artifacts must survive container)."""
+
+    @pytest.mark.parametrize("flow_file", _get_flow_files(), ids=lambda p: p.stem)
+    def test_no_tmp_in_flow_files(self, flow_file: Path) -> None:
+        tree = _parse_flow(flow_file)
+        imports = _get_imports(tree)
+
+        # Check for tempfile imports
+        tempfile_imports = [
+            (m, n) for m, n in imports if m == "tempfile" or n == "tempfile"
+        ]
+        assert not tempfile_imports, (
+            f"{flow_file.name} imports tempfile. "
+            "Temporary files are forbidden in flow code — artifacts must be volume-mounted. "
+            "Use explicit paths under /app/checkpoints, /mlruns, /logs, etc."
+        )
+
+        # Check for /tmp string literals
+        tmp_literals = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value.startswith("/tmp")
+        ]
+        assert not tmp_literals, (
+            f"{flow_file.name} contains '/tmp' string literal(s). "
+            "Paths under /tmp are not volume-mounted and will not survive container exit."
+        )
+
+
+class TestDockerComposeHasAllFlowServices:
+    """docker-compose.flows.yml must have a service entry for each core flow."""
+
+    def _load_compose(self) -> dict:
+        assert DOCKER_COMPOSE_FLOWS.exists(), (
+            f"docker-compose.flows.yml not found at {DOCKER_COMPOSE_FLOWS}. "
+            "Every flow must have a corresponding Docker service definition."
+        )
+        return yaml.safe_load(DOCKER_COMPOSE_FLOWS.read_text(encoding="utf-8"))
+
+    def test_docker_compose_has_all_flow_services(self) -> None:
+        compose = self._load_compose()
+        services = set(compose.get("services", {}).keys())
+        missing = CORE_DOCKER_SERVICES - services
+        assert not missing, (
+            f"docker-compose.flows.yml is missing service entries for: {missing}. "
+            "Every core Prefect flow must have a corresponding Docker service. "
+            "See CLAUDE.md Design Goal #2: Docker-per-flow isolation."
+        )

--- a/tests/v2/unit/test_pre_push_hook.py
+++ b/tests/v2/unit/test_pre_push_hook.py
@@ -1,0 +1,86 @@
+"""Tests for the pre-push hook infrastructure (#469).
+
+Verifies that:
+- scripts/pr_readiness_check.sh exists and is executable
+- The script contains all required validation commands
+- scripts/install-hooks.sh exists and wires the pre-push hook
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PR_READINESS = REPO_ROOT / "scripts" / "pr_readiness_check.sh"
+INSTALL_HOOKS = REPO_ROOT / "scripts" / "install-hooks.sh"
+
+
+class TestPrReadinessScript:
+    def test_pr_readiness_script_exists(self) -> None:
+        assert PR_READINESS.exists(), (
+            f"scripts/pr_readiness_check.sh not found at {PR_READINESS}. "
+            "Create it before wiring as a pre-push hook."
+        )
+
+    def test_pr_readiness_script_executable(self) -> None:
+        assert PR_READINESS.exists(), "pr_readiness_check.sh does not exist"
+        mode = os.stat(PR_READINESS).st_mode
+        assert mode & stat.S_IXUSR, (
+            "scripts/pr_readiness_check.sh is not user-executable. "
+            "Run: chmod +x scripts/pr_readiness_check.sh"
+        )
+
+    def test_pr_readiness_script_runs_pytest(self) -> None:
+        content = PR_READINESS.read_text(encoding="utf-8")
+        assert "pytest" in content, (
+            "scripts/pr_readiness_check.sh must invoke pytest. "
+            "Add: uv run pytest tests/unit/ -x -q --tb=short"
+        )
+
+    def test_pr_readiness_script_runs_ruff(self) -> None:
+        content = PR_READINESS.read_text(encoding="utf-8")
+        assert "ruff" in content, (
+            "scripts/pr_readiness_check.sh must invoke ruff. "
+            "Add: uv run ruff check src/minivess/ tests/"
+        )
+
+    def test_pr_readiness_script_runs_mypy(self) -> None:
+        content = PR_READINESS.read_text(encoding="utf-8")
+        assert "mypy" in content, (
+            "scripts/pr_readiness_check.sh must invoke mypy. "
+            "Add: uv run mypy src/minivess/"
+        )
+
+
+class TestInstallHooksScript:
+    def test_pre_push_hook_template_exists(self) -> None:
+        assert INSTALL_HOOKS.exists(), (
+            f"scripts/install-hooks.sh not found at {INSTALL_HOOKS}. "
+            "Create it to wire the pre-push hook for new contributors."
+        )
+
+    def test_install_hooks_is_executable(self) -> None:
+        assert INSTALL_HOOKS.exists(), "install-hooks.sh does not exist"
+        mode = os.stat(INSTALL_HOOKS).st_mode
+        assert mode & stat.S_IXUSR, (
+            "scripts/install-hooks.sh is not user-executable. "
+            "Run: chmod +x scripts/install-hooks.sh"
+        )
+
+    def test_install_hooks_references_pre_push(self) -> None:
+        assert INSTALL_HOOKS.exists(), "install-hooks.sh does not exist"
+        content = INSTALL_HOOKS.read_text(encoding="utf-8")
+        assert "pre-push" in content, (
+            "scripts/install-hooks.sh must create a pre-push git hook. "
+            "See .git/hooks/pre-push"
+        )
+
+    def test_install_hooks_references_pr_readiness(self) -> None:
+        assert INSTALL_HOOKS.exists(), "install-hooks.sh does not exist"
+        content = INSTALL_HOOKS.read_text(encoding="utf-8")
+        assert "pr_readiness_check.sh" in content, (
+            "scripts/install-hooks.sh must call scripts/pr_readiness_check.sh "
+            "from the pre-push hook body."
+        )


### PR DESCRIPTION
## Summary

- **Phase 1** (closes #424): Verified all 32 Docker enforcement tests pass. The suite covers `_require_docker_context()` gate in `train_flow.py`, checkpoint path validation in `SegmentationTrainer`, `.sh` script compliance, volume mount compliance in `docker-compose.flows.yml`, and no repo-relative paths in `src/`. No code changes needed — enforcement is complete.

- **Phase 2** (closes #469): Pre-push git hook infrastructure
  - `scripts/install-hooks.sh` — installs `.git/hooks/pre-push` that calls `scripts/pr_readiness_check.sh` before every `git push`
  - `tests/v2/unit/test_pre_push_hook.py` — 9 tests verifying scripts exist, are executable, and contain ruff/mypy/pytest calls

- **Phase 3**: Prefect decoupling invariants encoded as permanent tests
  - `tests/unit/orchestration/test_prefect_decoupling_verification.py` — 49 parametrized tests across all 12 flow files:
    - Every flow has `_require_docker_context()`
    - No cross-flow Python imports (flows communicate only via MLflow/Prefect artifacts)
    - Every flow imports `FLOW_NAME_*` from `orchestration.constants`
    - No `tempfile` or `/tmp` literals in any flow file
    - `docker-compose.flows.yml` has entries for all 6 core flows
  - Uses `ast.parse()` throughout (CLAUDE.md Rule #16 — no regex for structured data)

## Test plan

- [x] All 32 original enforcement tests pass (`MINIVESS_ALLOW_HOST=1 pytest tests/unit/orchestration/test_docker_context_gate.py ...`)
- [x] 9 pre-push hook tests pass (`pytest tests/v2/unit/test_pre_push_hook.py`)
- [x] 49 decoupling verification tests pass (`pytest tests/unit/orchestration/test_prefect_decoupling_verification.py`)
- [x] Full unit suite: 174 passed (`pytest tests/unit/ tests/v2/unit/test_pre_push_hook.py`)
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy, gitleaks, test-collection-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)