### PR TITLE
fix(deps): install all PRD-selected tools, fix 126 silent test skips

### DIFF
--- a/.claude/metalearning/2026-03-10-silent-test-skips-optional-deps.md
+++ b/.claude/metalearning/2026-03-10-silent-test-skips-optional-deps.md
@@ -1,0 +1,61 @@
+# Silent Test Skips from Optional Dependencies
+
+**Date**: 2026-03-10
+**Severity**: HIGH — 126 tests silently skipping = 126 tests that don't exist
+**Root Cause**: PRD-selected tools placed in `[project.optional-dependencies]` groups,
+but dev workflow used plain `uv sync` which doesn't install optional groups.
+
+## The Problem
+
+pyproject.toml had 6 optional groups (eval, quality, dev, agents, sam, serving)
+containing PRD-selected tools: pandera, hypothesis, great_expectations, whylogs,
+deepchecks, captum, shap, quantus, netcal, gradio, cleanlab, pydantic-ai, langfuse,
+braintrust.
+
+Tests used `pytest.importorskip()` to gracefully skip when tools were missing.
+This is correct behavior for *truly optional* features — but these tools were
+**selected in the PRD as required capabilities**. The "graceful skip" became a
+silent lie: tests appeared to pass when they were actually never running.
+
+## Additional Bugs Found
+
+1. **langgraph imported but never declared in pyproject.toml** — code in
+   `src/minivess/agents/_deprecated/` imported langgraph, tests guarded with
+   importorskip, but langgraph was NOT in any dependency group. Added to [agents].
+
+2. **litellm same situation** — imported in deprecated agents code, never declared.
+   Added to [agents].
+
+3. **Wrong mock path** — `test_agents.py::test_traced_run_creates_trace` patched
+   `minivess.agents.tracing._get_langfuse_client` but the function lives in
+   `minivess.agents._deprecated.tracing`. This was invisible because langgraph
+   not being installed caused the entire test class to skip before reaching it.
+
+## The Fix
+
+1. Added langgraph + litellm to `[project.optional-dependencies].agents`
+2. Ran `uv sync --all-extras` — installs ALL optional groups
+3. Fixed mock path in test_agents.py
+4. Updated CLAUDE.md Rule #1: `uv sync --all-extras` is REQUIRED for dev
+5. Updated Quick Commands: `uv sync` → `uv sync --all-extras`
+
+## Result
+
+- Before: 4010 passed, **28 skipped** (packages), many more silently deselected
+- After: **4136 passed, 2 skipped** (only hardware-specific: NVIDIA CTK config)
+
+## Anti-Pattern: Graceful Degradation as Silent Failure
+
+`pytest.importorskip()` is the right tool for *truly optional* integrations that
+only some users need. It is the WRONG tool for tools the project has committed to
+using. When a tool is selected in the PRD and has tests written for it, it MUST be
+installed in the dev environment. "Graceful skip" for committed tools = lying to
+yourself about test coverage.
+
+## Rule
+
+**If a tool has tests, it's not optional.** Either:
+- Install it (`--all-extras` or move to main deps)
+- Or delete the tests
+
+There is no third option where tests exist but never run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,11 @@ Each of the 6 Prefect flows runs in its own Docker container:
 
 ## Critical Rules
 
-1. **uv ONLY** — Never use pip, conda, poetry, or requirements.txt. Use `uv add`, `uv sync`, `uv run`.
+1. **uv ONLY** — Never use pip, conda, poetry, or requirements.txt. Use `uv add`, `uv sync --all-extras`, `uv run`.
+   **`--all-extras` is REQUIRED for dev installs.** Without it, PRD-selected tools
+   (pandera, hypothesis, great_expectations, whylogs, langgraph, deepchecks, captum,
+   quantus, gradio, etc.) are missing and 126+ tests silently skip. Plain `uv sync`
+   is BANNED for development — always use `uv sync --all-extras`.
 2. **TDD MANDATORY** — All implementation MUST follow the self-learning-iterative-coder skill (`.claude/skills/self-learning-iterative-coder/SKILL.md`). Write failing tests FIRST, then implement. No exceptions.
 3. **Library-First (Non-Negotiable)** — Before implementing ANY algorithm, loss function,
    metric, or data processing step, ALWAYS search for existing implementations in established
@@ -388,8 +392,8 @@ experiment config YAML which specifies the full loss list.
 ## Quick Commands
 
 ```bash
-# Install dependencies
-uv sync
+# Install dependencies (--all-extras is REQUIRED for dev — without it, 126 tests silently skip)
+uv sync --all-extras
 
 # Lint and format
 uv run ruff check src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ agents = [
     "pydantic-ai-slim[prefect,anthropic,openai]>=1.60,<2.0",
     "langfuse>=2.56,<3.0",
     "braintrust>=0.0.180,<1.0",
+    "langgraph>=0.4,<1.0",
+    "litellm>=1.70,<2.0",
 ]
 sam = [
     "sam2>=1.0,<2.0",

--- a/tests/v2/unit/test_agents.py
+++ b/tests/v2/unit/test_agents.py
@@ -243,7 +243,7 @@ class TestTracedGraphRun:
         traced_graph_run(mock_graph, state, trace_name="test_trace")
         mock_graph.invoke.assert_called_once_with(state)
 
-    @patch("minivess.agents.tracing._get_langfuse_client")
+    @patch("minivess.agents._deprecated.tracing._get_langfuse_client")
     def test_traced_run_creates_trace(self, mock_get_client: MagicMock) -> None:
         """Should create a Langfuse trace when client is available."""
         from minivess.agents._deprecated.tracing import traced_graph_run


### PR DESCRIPTION
## Summary

- **Add `langgraph` + `litellm`** to `[project.optional-dependencies].agents` — were imported in `src/minivess/agents/_deprecated/` but never declared in pyproject.toml
- **Fix mock path** in `test_agents.py` — patched `minivess.agents.tracing._get_langfuse_client` but function lives in `minivess.agents._deprecated.tracing` (invisible when langgraph missing caused entire class to skip)
- **Update CLAUDE.md Rule #1**: `uv sync --all-extras` is REQUIRED for dev installs. Plain `uv sync` is banned — it leaves 126 tests silently skipping via `pytest.importorskip()`
- **Add metalearning doc**: anti-pattern of graceful degradation masking missing committed tools

## Before → After

| Metric | Before | After |
|--------|--------|-------|
| Passed | 4010 | **4136** |
| Skipped | 28 (package) | **2** (hardware-only) |
| Package skips | pandera (14), whylogs (4), hypothesis (2), langgraph (3), great_expectations (1), litellm (4) | **0** |

## Test plan

- [x] `make test-staging` passes (4136 passed, 2 skipped)
- [x] All pre-commit hooks pass
- [x] `uv sync --all-extras` installs all 24 PRD-selected tools
- [x] No test uses `importorskip` for a tool that's now always installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)