### PR TITLE
fix: add patch size overrides for divisor≥16 models in quasi-e2e tests

### DIFF
--- a/src/minivess/testing/quasi_e2e_runner.py
+++ b/src/minivess/testing/quasi_e2e_runner.py
@@ -30,8 +30,15 @@ _PATCH_MAP: dict[str, tuple[int, int, int]] = {
     "sam3_vanilla": (16, 32, 32),
     "sam3_topolora": (16, 32, 32),
     "sam3_hybrid": (16, 32, 32),
-    # VesselFM: 6 encoder levels → needs >= 64 per dim
+    # VesselFM: 6 encoder levels → needs >= 64 per dim (divisor=32)
     "vesselfm": (64, 64, 64),
+    # SwinUNETR: 5 stride-2 levels → divisor=32, all dims >= 32
+    "swinunetr": (32, 32, 32),
+    # divisor=16 models: 4 stride-2 levels → D >= 16
+    "attentionunet": (32, 32, 16),
+    "unetr": (32, 32, 16),
+    "mamba": (32, 32, 16),
+    "ulike_mamba": (32, 32, 16),
 }
 _DEFAULT_PATCH: tuple[int, int, int] = (32, 32, 8)
 


### PR DESCRIPTION
## Summary
- AttentionUNet, UNETR, Mamba, ULike-Mamba have divisor=16 (4 stride-2 levels), requiring depth≥16 in test patches
- SwinUNETR has divisor=32, requiring all dims≥32
- Default test patch `(32, 32, 8)` with depth=8 caused MONAI attention gate forward pass crash: tensor size mismatch at non-singleton dimension
- Added model-specific entries to `_PATCH_MAP` in `quasi_e2e_runner.py`

## Test plan
- [x] `attentionunet__cbdice_cldice` — previously failing, now passes (5/5)
- [x] Full v2/unit suite: 4159 passed, 0 failures

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>