### PR TITLE
fix: UNETR/SwinUNETR quasi-e2e patch sizes — img_size and InstanceNorm

### DIFF
--- a/src/minivess/testing/quasi_e2e_runner.py
+++ b/src/minivess/testing/quasi_e2e_runner.py
@@ -32,8 +32,9 @@ _PATCH_MAP: dict[str, tuple[int, int, int]] = {
     "sam3_hybrid": (16, 32, 32),
     # VesselFM: 6 encoder levels → needs >= 64 per dim (divisor=32)
     "vesselfm": (64, 64, 64),
-    # SwinUNETR: 5 stride-2 levels → divisor=32, all dims >= 32
-    "swinunetr": (32, 32, 32),
+    # SwinUNETR: 5 stride-2 levels → divisor=32; InstanceNorm needs spatial>1
+    # at bottleneck, so all dims must be > 32 (use 64)
+    "swinunetr": (64, 64, 64),
     # divisor=16 models: 4 stride-2 levels → D >= 16
     "attentionunet": (32, 32, 16),
     "unetr": (32, 32, 16),
@@ -71,11 +72,17 @@ def _model_name_to_family(model_name: str) -> str:
     raise ValueError(msg)
 
 
+# Models that need img_size in architecture_params to match the test patch.
+# UNETR uses img_size for positional embedding computation — mismatch crashes.
+_IMG_SIZE_MODELS = frozenset({"unetr"})
+
+
 def build_model_for_test(
     model_name: str,
     *,
     in_channels: int = 1,
     out_channels: int = 2,
+    patch_size: tuple[int, int, int] | None = None,
 ) -> nn.Module:
     """Instantiate a model adapter's nn.Module for testing.
 
@@ -91,6 +98,9 @@ def build_model_for_test(
         Input channels (default 1 for grayscale).
     out_channels:
         Output channels/classes (default 2 for binary seg).
+    patch_size:
+        Test patch size. For UNETR, this is used to set ``img_size``
+        in architecture_params so positional embeddings match input.
 
     Returns
     -------
@@ -108,11 +118,16 @@ def build_model_for_test(
     family_value = _model_name_to_family(model_name)
     family = ModelFamily(family_value)
 
+    arch_params: dict[str, Any] = {}
+    if model_name in _IMG_SIZE_MODELS and patch_size is not None:
+        arch_params["img_size"] = list(patch_size)
+
     config = ModelConfig(
         family=family,
         name=model_name,
         in_channels=in_channels,
         out_channels=out_channels,
+        architecture_params=arch_params,
     )
 
     return build_adapter(config)

--- a/tests/v2/quasi_e2e/test_all_combinations.py
+++ b/tests/v2/quasi_e2e/test_all_combinations.py
@@ -33,7 +33,8 @@ class TestModelLossForwardBackward:
 
     def test_model_instantiates(self, model_loss_combo: TestCombination) -> None:
         """Model can be instantiated from config."""
-        model = build_model_for_test(model_loss_combo.model)
+        patch = _get_patch_size_for_model(model_loss_combo.model)
+        model = build_model_for_test(model_loss_combo.model, patch_size=patch)
         assert model is not None
 
     def test_loss_instantiates(self, model_loss_combo: TestCombination) -> None:
@@ -45,12 +46,13 @@ class TestModelLossForwardBackward:
         self, model_loss_combo: TestCombination
     ) -> None:
         """Single forward+backward pass completes without error."""
-        model = build_model_for_test(model_loss_combo.model)
+        patch = _get_patch_size_for_model(model_loss_combo.model)
+        model = build_model_for_test(model_loss_combo.model, patch_size=patch)
         loss_fn = build_loss_for_test(model_loss_combo.loss)
         result = run_single_forward_backward(
             model=model,
             loss_fn=loss_fn,
-            patch_size=_get_patch_size_for_model(model_loss_combo.model),
+            patch_size=patch,
             batch_size=1,
             in_channels=1,
             num_classes=2,
@@ -59,12 +61,13 @@ class TestModelLossForwardBackward:
 
     def test_loss_is_finite(self, model_loss_combo: TestCombination) -> None:
         """Loss value is finite (not NaN or Inf)."""
-        model = build_model_for_test(model_loss_combo.model)
+        patch = _get_patch_size_for_model(model_loss_combo.model)
+        model = build_model_for_test(model_loss_combo.model, patch_size=patch)
         loss_fn = build_loss_for_test(model_loss_combo.loss)
         result = run_single_forward_backward(
             model=model,
             loss_fn=loss_fn,
-            patch_size=_get_patch_size_for_model(model_loss_combo.model),
+            patch_size=patch,
             batch_size=1,
             in_channels=1,
             num_classes=2,
@@ -79,12 +82,13 @@ class TestModelLossForwardBackward:
 
     def test_gradients_flow(self, model_loss_combo: TestCombination) -> None:
         """Gradients are non-zero after backward pass."""
-        model = build_model_for_test(model_loss_combo.model)
+        patch = _get_patch_size_for_model(model_loss_combo.model)
+        model = build_model_for_test(model_loss_combo.model, patch_size=patch)
         loss_fn = build_loss_for_test(model_loss_combo.loss)
         result = run_single_forward_backward(
             model=model,
             loss_fn=loss_fn,
-            patch_size=_get_patch_size_for_model(model_loss_combo.model),
+            patch_size=patch,
             batch_size=1,
             in_channels=1,
             num_classes=2,


### PR DESCRIPTION
## Summary
- **UNETR**: Position embeddings require `img_size` at construction matching actual patch. Added `patch_size` param to `build_model_for_test()` that sets `architecture_params.img_size` for UNETR
- **SwinUNETR**: InstanceNorm requires spatial size > 1 at bottleneck. Changed patch from `(32,32,32)` to `(64,64,64)` (divisor=32 → bottleneck=2 instead of 1)
- Test file updated to pass `patch_size` to model builder for all combos

## Test plan
- [x] `unetr__cbdice_cldice` — 10 passed (previously crashing)
- [x] `swinunetr__cbdice_cldice` — 5 passed
- [x] Full quasi-e2e (non-SAM3): 55 passed, 0 failures
- [x] Pre-commit: all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>