### PR TITLE
perf: mark SAM3 quasi-e2e tests as slow + model_loading (#596)

### DIFF
--- a/tests/v2/quasi_e2e/conftest.py
+++ b/tests/v2/quasi_e2e/conftest.py
@@ -3,7 +3,8 @@
 Discovers all implemented model×loss combinations from the capability
 schema and dynamically parametrizes tests at collection time.
 
-SAM3 TopoLoRA tests are auto-skipped when GPU VRAM < 16 GB.
+SAM3 tests are marked ``slow`` + ``model_loading`` so they're excluded from
+staging/prod tiers.  SAM3 TopoLoRA is additionally skipped on <16 GB VRAM.
 """
 
 from __future__ import annotations
@@ -14,7 +15,10 @@ import torch
 from minivess.testing.capability_discovery import (
     build_practical_combinations,
 )
-from minivess.testing.quasi_e2e_runner import generate_test_ids
+from minivess.testing.quasi_e2e_runner import (
+    _SAM3_MODELS,
+    generate_test_ids,
+)
 
 
 def _gpu_vram_gb() -> float:
@@ -22,6 +26,11 @@ def _gpu_vram_gb() -> float:
     if not torch.cuda.is_available():
         return 0.0
     return torch.cuda.get_device_properties(0).total_memory / (1024**3)
+
+
+def _is_sam3_test(nodeid: str) -> bool:
+    """Return True if the test nodeid belongs to a SAM3 model combo."""
+    return any(name in nodeid for name in _SAM3_MODELS)
 
 
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
@@ -36,14 +45,28 @@ def pytest_collection_modifyitems(
     config: pytest.Config,
     items: list[pytest.Item],
 ) -> None:
-    """Skip sam3_topolora tests when GPU VRAM < 16 GB."""
-    vram = _gpu_vram_gb()
-    if vram >= 16.0:
-        return
+    """Mark SAM3 tests as slow + model_loading; skip sam3_topolora on low VRAM.
 
-    skip_marker = pytest.mark.skip(
-        reason=(f"SAM3 TopoLoRA requires >= 16 GB VRAM (detected {vram:.1f} GB)"),
+    SAM3 model loading (ViT-32L, 848M params from HuggingFace) takes >60 min
+    on dev machines.  Marking with ``slow`` and ``model_loading`` ensures the
+    staging tier (``-m "not model_loading and not slow"``) excludes them.
+    """
+    vram = _gpu_vram_gb()
+    slow_marker = pytest.mark.slow
+    model_loading_marker = pytest.mark.model_loading
+
+    skip_topolora = pytest.mark.skip(
+        reason=f"SAM3 TopoLoRA requires >= 16 GB VRAM (detected {vram:.1f} GB)",
     )
+
     for item in items:
-        if "sam3_topolora" in item.nodeid:
-            item.add_marker(skip_marker)
+        if not _is_sam3_test(item.nodeid):
+            continue
+
+        # All SAM3 combos: mark slow + model_loading
+        item.add_marker(slow_marker)
+        item.add_marker(model_loading_marker)
+
+        # sam3_topolora additionally needs ≥16 GB VRAM
+        if "sam3_topolora" in item.nodeid and vram < 16.0:
+            item.add_marker(skip_topolora)

--- a/tests/v2/unit/test_sam3_quasi_e2e_markers.py
+++ b/tests/v2/unit/test_sam3_quasi_e2e_markers.py
@@ -1,0 +1,87 @@
+"""Tests that SAM3 quasi-e2e combos are marked slow + model_loading (#596).
+
+SAM3 model loading (ViT-32L, 848M params, HuggingFace download) takes >60 min
+on dev machines. These combos must be marked so they're excluded from staging/prod
+tiers and only run on GPU instances or when explicitly selected.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from minivess.testing.quasi_e2e_runner import _SAM3_MODELS
+
+CONFTEST_PATH = Path("tests/v2/quasi_e2e/conftest.py")
+
+
+class TestSam3QuasiE2eMarkers:
+    """Verify SAM3 quasi-e2e tests get appropriate markers."""
+
+    def test_conftest_adds_slow_marker_to_sam3(self) -> None:
+        """pytest_collection_modifyitems must add 'slow' marker to SAM3 combos."""
+        source = CONFTEST_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        # Find the pytest_collection_modifyitems function
+        func_found = False
+        marks_slow = False
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "pytest_collection_modifyitems"
+            ):
+                func_found = True
+                # Walk the function body for pytest.mark.slow references
+                func_source = ast.dump(node)
+                if "slow" in func_source:
+                    marks_slow = True
+                break
+
+        assert func_found, "pytest_collection_modifyitems not found in conftest"
+        assert marks_slow, (
+            "pytest_collection_modifyitems does not add 'slow' marker to SAM3 combos"
+        )
+
+    def test_conftest_adds_model_loading_marker_to_sam3(self) -> None:
+        """pytest_collection_modifyitems must add 'model_loading' marker to SAM3 combos."""
+        source = CONFTEST_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        func_found = False
+        marks_model_loading = False
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "pytest_collection_modifyitems"
+            ):
+                func_found = True
+                func_source = ast.dump(node)
+                if "model_loading" in func_source:
+                    marks_model_loading = True
+                break
+
+        assert func_found, "pytest_collection_modifyitems not found in conftest"
+        assert marks_model_loading, (
+            "pytest_collection_modifyitems does not add 'model_loading' marker to SAM3 combos"
+        )
+
+    def test_conftest_checks_all_sam3_models(self) -> None:
+        """The conftest must reference _SAM3_MODELS or check all three SAM3 model names."""
+        source = CONFTEST_PATH.read_text(encoding="utf-8")
+
+        # Either imports _SAM3_MODELS or checks all three model names
+        uses_frozenset = "_SAM3_MODELS" in source
+        checks_all_names = all(name in source for name in _SAM3_MODELS)
+
+        assert uses_frozenset or checks_all_names, (
+            f"conftest must check all SAM3 models: {sorted(_SAM3_MODELS)}. "
+            "Import _SAM3_MODELS from quasi_e2e_runner or check each name."
+        )
+
+    def test_sam3_models_frozenset_has_expected_members(self) -> None:
+        """_SAM3_MODELS must contain exactly the known SAM3 variants."""
+        expected = {"sam3_vanilla", "sam3_topolora", "sam3_hybrid"}
+        assert expected == _SAM3_MODELS, (
+            f"_SAM3_MODELS mismatch: got {_SAM3_MODELS}, expected {expected}"
+        )


### PR DESCRIPTION
## Summary
- Mark all SAM3 quasi-e2e combos with `slow` + `model_loading` markers so they're excluded from staging/prod tiers automatically
- SAM3 model loading (ViT-32L, 848M params from HuggingFace) takes >60min on dev machines — these tests should only run on GPU instances or when explicitly selected
- Keep existing `sam3_topolora` VRAM skip (<16 GB) alongside the new markers
- Import `_SAM3_MODELS` frozenset from `quasi_e2e_runner` into conftest for single-source model name list

## Test plan
- [x] 4 new TDD tests verify marker assignment (`test_sam3_quasi_e2e_markers.py`)
- [x] Staging tier: 4168 passed, 0 failures
- [x] Collection verify: `pytest tests/v2/quasi_e2e/ --collect-only -m "not slow"` → 25 SAM3 combos deselected, 55 remain
- [x] Pre-commit: all hooks pass (ruff, mypy, format)

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)