### PR TITLE
fix(adapters): SAM3 adapter fixes + NaN investigation + atomic checkpoints

### DIFF
--- a/.claude/metalearning/2026-03-13-vram-estimate-inconsistency.md
+++ b/.claude/metalearning/2026-03-13-vram-estimate-inconsistency.md
@@ -1,0 +1,117 @@
+# 2026-03-13 — VRAM Estimate Inconsistency (Recurring Failure)
+
+## The Problem
+
+Claude Code repeatedly provides **different VRAM estimates for the same model** across
+conversations and even within a single conversation. The user has observed this pattern
+multiple times, causing justified frustration and eroding trust.
+
+## Specific Incident (2026-03-13)
+
+A reviewer agent "corrected" VesselFM VRAM from 10 GB → 6 GB in the RunPod smoke test
+plan, claiming the original was wrong. This was itself wrong:
+
+- `configs/model_profiles/vesselfm.yaml:18` states: **~6 GB inference, ~10 GB fine-tuning**
+- The smoke test does **fine-tuning**, not inference
+- The reviewer confused inference with fine-tuning — halving the estimate
+- The plan author (also Claude) accepted this "correction" without verifying
+
+This is the same model, in the same repo, with the VRAM number written in a YAML file —
+and Claude still got it wrong.
+
+## Root Cause Analysis
+
+### Why This Keeps Happening
+
+1. **No single source of truth**: VRAM numbers are scattered across 9+ files:
+   - `configs/model_profiles/*.yaml` (per-model hardware profiles)
+   - `src/minivess/adapters/CLAUDE.md` (adapter context doc)
+   - `CLAUDE.md` (root project doc — "Models Fitting 8GB GPU" table)
+   - `LEARNINGS.md` (accumulated discoveries)
+   - `docs/planning/*.md` (planning docs with estimates)
+   - `.claude/metalearning/*.md` (failure analysis)
+   - `.claude/projects/.../memory/MEMORY.md` (auto-memory)
+   - `src/minivess/adapters/sam3_vram_check.py` (enforcement code)
+
+   Each file has a different subset of models, different numbers, and different dates.
+
+2. **No distinction between MEASURED vs ESTIMATED**: The word "estimated" appears in
+   `vesselfm.yaml:18` but not in any standardized way. There's no field like
+   `vram_measured: true/false` or `vram_source: "RTX 2070 Super benchmark 2026-03-07"`.
+
+3. **Inference vs training conflated**: VesselFM has 6 GB (inference) and 10 GB
+   (fine-tuning) — a 67% difference. Without reading the full YAML comment, Claude
+   picks whichever number seems "right" for the context.
+
+4. **Stale estimates propagate**: LEARNINGS.md line 49 says SAM3 V1 Vanilla needs
+   "≥16 GB" — an initial estimate from 2026-03-07 that was corrected by actual
+   measurement (2.9 GB). But the stale 16 GB number still exists in the file.
+
+5. **LLM stochastic recall**: Claude doesn't deterministically remember which number
+   is authoritative. Different conversation turns, different context windows, different
+   token sampling → different numbers produced with equal confidence.
+
+## What Must Change
+
+### Single Source of Truth: `configs/model_profiles/*.yaml`
+
+The model profile YAML files MUST be the **authoritative, canonical source** for all
+VRAM requirements. Every other file that mentions VRAM must either:
+- **Reference** the profile: "See `configs/model_profiles/vesselfm.yaml`"
+- **Be deleted** (if it's a stale duplicate)
+
+### Required Fields in Model Profiles
+
+Each `configs/model_profiles/*.yaml` MUST include:
+
+```yaml
+vram:
+  inference_gb: 6.0      # GPU memory for inference only
+  training_gb: 10.0      # GPU memory for fine-tuning (batch=1)
+  measured: false         # true = actual benchmark, false = estimate
+  measured_gpu: null      # e.g., "RTX 2070 Super" if measured
+  measured_date: null     # e.g., "2026-03-07" if measured
+  measured_config:        # patch size, batch size, etc. if measured
+    patch_size: null
+    batch_size: null
+  notes: "Estimated based on DynUNet architecture with wider filters"
+```
+
+### Current Measured vs Estimated Status
+
+| Model | Inference | Training | MEASURED? | GPU | Date |
+|-------|-----------|----------|-----------|-----|------|
+| DynUNet | ~3.5 GB | ~3.5 GB | **YES** | RTX 2070 Super | 2026-03-07 |
+| SAM3 V1 Vanilla | 2.9 GB | 3.5 GB | **YES** | RTX 2070 Super | 2026-03-07 |
+| SAM3 Hybrid | 7.18 GiB (OOM@64) | TBD | **PARTIAL** | RTX 2070 Super | 2026-03-09 |
+| SAM3 V2 TopoLoRA | TBD | ≥16 GB est | **NO** | — | — |
+| VesselFM | ~6 GB est | ~10 GB est | **NO** | — | — |
+
+### Rule for Claude Code
+
+**NEVER estimate VRAM from architecture description.** The ONLY valid sources are:
+1. `configs/model_profiles/*.yaml` — read the file, quote the number
+2. Actual benchmark results — cite the log file or measurement session
+
+If asked "how much VRAM does VesselFM need?", the answer is:
+> "configs/model_profiles/vesselfm.yaml says ~6 GB inference, ~10 GB fine-tuning.
+> These are ESTIMATES, not measured. No benchmark has been run."
+
+NOT: "VesselFM uses DynUNet with wider filters, so probably ~6 GB" — this is the
+exact stochastic guessing that caused this incident.
+
+## Prior Incidents
+
+- **2026-03-02**: SAM3 confused with SAM2, wildly wrong VRAM estimates
+  (see `.claude/metalearning/2026-03-02-sam3-implementation-fuckup.md`)
+- **2026-03-09**: SAM3 Hybrid OOM at patch=(64,64,3) discovered during actual training
+  (see `configs/model_profiles/sam3_hybrid.yaml` comments)
+- **2026-03-13**: VesselFM 10 GB → 6 GB "correction" by reviewer agent (this incident)
+
+## Action Items
+
+1. Add structured `vram:` section to all model profiles (T-immediate)
+2. Delete stale VRAM numbers from LEARNINGS.md, CLAUDE.md, MEMORY.md — replace with
+   references to model profiles
+3. Run actual VesselFM VRAM benchmark on RTX 4090 during smoke test (T4.1)
+4. Add pre-commit hook or test that validates VRAM numbers are only in model profiles

--- a/.claude/metalearning/2026-03-15-sam3-bf16-fp16-fuckup.md
+++ b/.claude/metalearning/2026-03-15-sam3-bf16-fp16-fuckup.md
@@ -1,0 +1,74 @@
+# Metalearning: SAM3 BF16 vs FP16 — Lost Institutional Knowledge
+
+**Date**: 2026-03-15
+**Category**: Knowledge amnesia, repeated discovery
+**Severity**: HIGH — caused unnecessary debugging, potential NaN source
+
+## What Happened
+
+SAM3's official HuggingFace model card uses `torch.bfloat16` in all examples:
+```python
+model = Sam3VideoModel.from_pretrained("facebook/sam3").to(device, dtype=torch.bfloat16)
+```
+
+But `sam3_backbone.py` was written with `torch.float16`:
+```python
+Sam3Model.from_pretrained("facebook/sam3", torch_dtype=torch.float16, ...)
+```
+
+**BF16 was one of the original reasons for pursuing cloud GPUs** — the RTX 2070
+Super (Turing architecture, compute capability 7.5) does NOT support BF16 natively.
+Cloud GPUs (Ampere+: A100, RTX 3090, RTX 4090) DO support BF16.
+
+Yet when we moved to cloud, we kept using FP16 instead of switching to BF16.
+This knowledge was known, discussed, and then lost — classic knowledge amnesia.
+
+## Why This Matters
+
+- **FP16 range**: max 65504. BF16 range: same as FP32 (3.4e38)
+- **SAM3 ViT-32L**: 648M params, massive intermediate activations
+- **Known pattern**: mT5 (pretrained BF16 on TPU) → NaN when fine-tuned with FP16
+  (HuggingFace discuss). SAM3 follows the same pattern.
+- **Instance norm + FP16**: batch_size=1 with small variance → overflow → NaN
+- **AMP autocast**: adds another layer of FP16 risk on 3D operations
+
+## Root Cause of Knowledge Loss
+
+1. **sam3_backbone.py was written for 8 GB GPU (RTX 2070 Super)**. FP16 was the
+   only option — BF16 unsupported on Turing.
+2. **When cloud was added**, nobody updated the dtype. The code "worked" (encoder
+   output was clean) so nobody questioned FP16 vs BF16.
+3. **The val_loss=NaN turned out to be a sentinel** (H1 CONFIRMED), so the BF16
+   issue was never directly observed as a failure — but it remains a latent risk.
+4. **No connection was made** between "we need cloud for BF16" (project knowledge)
+   and "sam3_backbone.py uses FP16" (code fact).
+
+## Prevention
+
+1. **CLAUDE.md / adapters/CLAUDE.md**: Add explicit note that SAM3 should use
+   BF16 on Ampere+ GPUs, FP16 only as fallback for Turing.
+2. **sam3_backbone.py**: Auto-detect GPU capability and use BF16 when available:
+   ```python
+   if torch.cuda.is_bf16_supported():
+       torch_dtype = torch.bfloat16
+   else:
+       torch_dtype = torch.float16  # Turing fallback
+   ```
+3. **Memory files**: The "why cloud" rationale should include specific technical
+   reasons (BF16 support) not just "bigger GPU." Vague reasons get lost.
+
+## Lesson
+
+**When the reason for a technical decision is a specific hardware capability,
+codify it as an assertion or auto-detection in the code itself.** Documentation
+gets ignored; code enforces. The BF16 requirement should have been encoded as
+`torch_dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16`
+from day one — then the "institutional knowledge" lives in the code, not in
+someone's memory.
+
+## Related
+
+- `.claude/metalearning/2026-03-02-sam3-implementation-fuckup.md` — original SAM3 mistakes
+- `src/minivess/adapters/CLAUDE.md` — SAM3 VRAM and dtype tables
+- `docs/planning/sam3-nan-loss-fix.md` — NaN investigation with BF16 finding
+- HuggingFace model card: `facebook/sam3` — official BF16 examples

--- a/configs/experiment/sam3_hybrid_full.yaml
+++ b/configs/experiment/sam3_hybrid_full.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+# SAM3 Hybrid Full-Dataset Training (≥24 GB GPU required)
+#
+# Tests H4: whether SAM3 hybrid converges with sufficient data.
+# Full MiniVess dataset: 47 train volumes, 3 folds, 50 epochs.
+# Conservative lr=1e-4 for frozen encoder (H5 mitigation).
+#
+# Run on cloud GPU (RTX 4090, A100, etc.) via SkyPilot:
+#   sky launch deployment/skypilot/dev_runpod.yaml --env MODEL_FAMILY=sam3_hybrid
+#   (then set EXPERIMENT=sam3_hybrid_full in the run block)
+defaults:
+  - override /model: sam3_hybrid
+  - override /checkpoint: lightweight
+
+experiment_name: sam3_hybrid_full
+model: sam3_hybrid
+model_family: sam3_hybrid
+losses:
+  - cbdice_cldice
+max_epochs: 50
+num_folds: 3
+debug: false
+
+# Validate every 5 epochs (balance cost vs insight)
+val_interval: 5
+
+# Conservative LR for frozen ViT-32L encoder (H5 mitigation)
+learning_rate: 0.0001
+
+# Full dataset (no subsetting)
+splits_file: configs/splits/3fold_seed42.json
+
+# DVC provenance
+data:
+  dvc_commit: HEAD
+
+architecture_params:
+  backbone: vit_32l
+  input_size: 1008
+  embed_dim: 1024
+  pretrained: false

--- a/docs/planning/dev-runpod-doublecheck-code-review.xml
+++ b/docs/planning/dev-runpod-doublecheck-code-review.xml
@@ -1,0 +1,858 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Dev + RunPod Doublecheck Code Review Plan v1.0
+  Created: 2026-03-15
+  Branch: feat/skypilot-runpod-gpu-offloading
+  Author: Claude Opus 4.6
+
+  PURPOSE: Comprehensive code review + production polish for all RunPod dev
+  infrastructure, SAM3 adapters, VesselFM adapter, and GCP cloud code.
+  Dual mandate: (1) verify model correctness, (2) production-grade DevEx.
+
+  SKILL: self-learning-iterative-coder (TDD loop)
+  MONITOR: ralph-loop (infrastructure health)
+
+  PHASES:
+    P0 — Critical bugs from code review (local, no GPU)
+    P1 — val_loss=NaN multi-hypothesis investigation (#710)
+    P2 — Adapter code deduplication + production polish (/simplify)
+    P3 — Issue triage: close resolved, file new
+    P4 — GCP code hardening
+    P5 — Cloud verification (requires RunPod/GCP credits)
+-->
+
+<plan version="1.0" name="dev-runpod-doublecheck-code-review">
+
+  <metadata>
+    <created>2026-03-15</created>
+    <branch>feat/skypilot-runpod-gpu-offloading</branch>
+    <prerequisite-issues>
+      <issue number="710" title="sam3_hybrid val_loss=NaN on RTX 4090" priority="P0" />
+      <issue number="680" title="sam3_topolora OOM — needs gradient checkpointing" priority="P0" />
+      <issue number="707" title="Atomic checkpoint writes for spot preemption" priority="P1" />
+      <issue number="686" title="SkyPilot spot checkpointing MOUNT_CACHED" priority="P1" />
+      <issue number="689" title="MLflow env var resolution on RunPod" priority="P1" />
+      <issue number="703" title="Cloud GPU strategy in CLAUDE.md" priority="P1" />
+      <issue number="690" title="Makefile/Justfile targets for RunPod dev" priority="P2" />
+      <issue number="692" title="RunPod idle monitor with auto-shutdown" priority="P2" />
+    </prerequisite-issues>
+    <reviewer-agents>
+      <agent name="adapter-reviewer" scope="src/minivess/adapters/" focus="FP16 consistency, dim order, LoRA correctness" />
+      <agent name="trainer-reviewer" scope="src/minivess/pipeline/trainer.py" focus="validation logic, checkpoint safety, NaN handling" />
+      <agent name="skypilot-reviewer" scope="deployment/skypilot/" focus="env var resolution, hardcoded URLs, Docker-only" />
+      <agent name="simplify-agent" scope="src/minivess/adapters/" focus="deduplication, code reuse, production quality" />
+    </reviewer-agents>
+  </metadata>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       PHASE 0: Critical Bugs from Code Review (LOCAL — no GPU needed)
+       ═══════════════════════════════════════════════════════════════════ -->
+  <phase id="P0" name="Critical Bugs from Code Review" environment="local" blocked="false">
+    <description>
+      Fix all critical and medium-severity bugs found by the adapter code review.
+      These are code-level fixes that can be tested locally without GPU.
+    </description>
+
+    <task id="T0.1" name="Remove dead Conv2d LoRA path in sam3_topolora"
+          priority="P1" estimated-iterations="1">
+      <description>
+        LoRALinear.forward() has a Conv2d branch that averages spatial dims and
+        reconstructs via unsqueeze — mathematically wrong for convolutions. SAM3
+        is pure ViT (all Linear), so this branch is NEVER executed. Remove it
+        with a clear error message to prevent silent failures if architecture changes.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/sam3_topolora.py" action="edit" />
+        <file path="tests/v2/unit/adapters/test_sam3_topolora_lora.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that LoRALinear raises TypeError for Conv2d input.
+          Test that LoRALinear works correctly for nn.Linear input.
+          Test that LoRA forward handles FP16→FP32 dtype casting.
+        </red>
+        <green>
+          Remove Conv2d branch from LoRALinear.__init__() and forward().
+          Keep only Linear support with clear TypeError for unsupported types.
+          Remove _is_conv flag.
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T0.2" name="Add input shape validation to sam3_backbone._preprocess()"
+          priority="P1" estimated-iterations="1">
+      <description>
+        sam3_backbone._preprocess() assumes 4D input (B,C,H,W) but has no validation.
+        A 3D tensor causes cryptic IndexError. Add explicit ndim check with helpful
+        error message mentioning MONAI's (B,C,H,W,D) convention.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/sam3_backbone.py" action="edit" />
+        <file path="tests/v2/unit/adapters/test_sam3_backbone_validation.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that _preprocess raises ValueError for 3D input.
+          Test that _preprocess raises ValueError for 5D input.
+          Test that _preprocess accepts 4D input without error.
+        </red>
+        <green>
+          Add `if x.ndim != 4: raise ValueError(...)` at top of _preprocess().
+          Error message: "Expected 4D input (B,C,H,W) for 2D slice, got {x.ndim}D.
+          SAM3 adapters process 3D volumes slice-by-slice; pass individual slices."
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T0.3" name="Standardize checkpoint load/save error handling"
+          priority="P1" estimated-iterations="1">
+      <description>
+        torch.load() in 3 SAM3 adapters has no error handling for missing files.
+        sam3_feature_cache.py has proper FileNotFoundError pattern. Standardize
+        all adapters to check path.exists() before loading.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/sam3_vanilla.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_topolora.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_hybrid.py" action="edit" />
+        <file path="tests/v2/unit/adapters/test_checkpoint_error_handling.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that load_checkpoint raises FileNotFoundError for nonexistent path.
+          Test that load_checkpoint succeeds for valid checkpoint file.
+          Test for all 3 adapters: sam3_vanilla, sam3_topolora, sam3_hybrid.
+        </red>
+        <green>
+          Add `if not path.exists(): raise FileNotFoundError(f"No checkpoint at {path}")`.
+          Same pattern as sam3_feature_cache.py:99-101.
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T0.4" name="Fix sam3_vanilla dimension ordering bug (dim=4 → dim=2)"
+          priority="P0" estimated-iterations="2">
+      <description>
+        CRITICAL BUG DISCOVERED: SegmentationOutput at base.py:19 specifies
+        logits shape as (B, C, D, H, W) — depth is THIRD spatial dim.
+        Standard MONAI and PyTorch 3D convention is also (B, C, D, H, W).
+
+        Actual adapter behavior:
+        - sam3_hybrid: torch.stack(dim=2) → (B, C, D, H, W) ← CORRECT
+        - sam3_topolora: torch.stack(dim=2) → (B, C, D, H, W) ← CORRECT
+        - sam3_vanilla: torch.stack(dim=4) → (B, C, H, W, D) ← WRONG
+
+        sam3_vanilla is the ONLY adapter that puts depth LAST. This likely
+        hasn't caused errors because the smoke test patch_size=(64,64,3) has
+        asymmetric spatial dims (H=W=64, D=3) and MONAI losses may handle
+        both orderings when shapes are distinguishable.
+
+        ALSO: adapters/CLAUDE.md incorrectly states "MONAI uses (B,C,H,W,D)
+        depth LAST". This is wrong — standard MONAI/PyTorch uses (B,C,D,H,W).
+        The CLAUDE.md documentation led to the sam3_vanilla bug.
+
+        Fix: Change sam3_vanilla.py:118 from dim=4 to dim=2.
+        Fix: Update adapters/CLAUDE.md dimension documentation.
+        Fix: Update root CLAUDE.md if it mentions (B,C,H,W,D).
+        Add: Shape assertion after torch.stack() in all SAM3 adapters.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/sam3_vanilla.py" action="edit" />
+        <file path="src/minivess/adapters/CLAUDE.md" action="edit" />
+        <file path="tests/v2/unit/adapters/test_sam3_output_shape.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that sam3_vanilla output has shape (B, C, D, H, W) with D in dim 2.
+          Test that sam3_topolora output has shape (B, C, D, H, W) with D in dim 2.
+          Test that sam3_hybrid output has shape (B, C, D, H, W) with D in dim 2.
+          Use asymmetric input (H=8, W=8, D=3) so dim mismatch is detectable.
+        </red>
+        <green>
+          Change sam3_vanilla.py:118 from torch.stack(dim=4) to torch.stack(dim=2).
+          Update adapters/CLAUDE.md: (B,C,H,W,D) → (B,C,D,H,W).
+          Add assert logits_3d.shape[2] == d after stack in all SAM3 adapters.
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T0.5" name="Atomic checkpoint writes (tmp + rename)"
+          priority="P0" estimated-iterations="2">
+      <description>
+        trainer.py and multi_metric_tracker.py use direct torch.save() without
+        atomic write pattern. If spot instance is preempted mid-write, checkpoint
+        file is corrupted. ralph_monitor.py already detects this failure pattern
+        ("inline_container.cc") but the fix is not implemented.
+
+        Implement: write to tmp file, then os.replace() (atomic on POSIX).
+        This is critical for spot instance reliability (#707).
+      </description>
+      <files>
+        <file path="src/minivess/pipeline/trainer.py" action="edit" />
+        <file path="src/minivess/pipeline/multi_metric_tracker.py" action="edit" />
+        <file path="tests/v2/unit/pipeline/test_atomic_checkpoint.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that checkpoint save creates a temporary file first.
+          Test that checkpoint save uses os.replace() for atomicity.
+          Test that interrupted save leaves no corrupted checkpoint.
+          Test that valid checkpoint is readable after atomic save.
+        </red>
+        <green>
+          Create helper: `_atomic_save(state_dict, path)` that:
+            1. Writes to `path.with_suffix('.tmp')`
+            2. Calls `os.replace(tmp_path, path)` (POSIX atomic)
+            3. Handles cleanup on exception
+          Use in trainer.py (lines 757-764, 802-805) and multi_metric_tracker.py:270.
+        </green>
+      </tdd-spec>
+      <issue number="707" action="close" reason="Atomic writes implemented" />
+    </task>
+
+    <task id="T0.6" name="Fix hardcoded Cloud Run URL in smoke_test_gcp.yaml"
+          priority="P1" estimated-iterations="1">
+      <description>
+        deployment/skypilot/smoke_test_gcp.yaml line 42 has hardcoded
+        Cloud Run URL. Replace with ${MLFLOW_GCP_URI} env var reference.
+        Per CLAUDE.md Rule #22: all service URLs via .env.example.
+      </description>
+      <files>
+        <file path="deployment/skypilot/smoke_test_gcp.yaml" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>No test — config file change. Verify YAML is valid.</red>
+        <green>Replace hardcoded URL with ${MLFLOW_GCP_URI} env var.</green>
+      </tdd-spec>
+    </task>
+
+    <github-issue-group value="P0-code-review-fixes">T0.1,T0.2,T0.3,T0.4,T0.5,T0.6</github-issue-group>
+  </phase>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       PHASE 1: val_loss=NaN Multi-Hypothesis Investigation (#710)
+       ═══════════════════════════════════════════════════════════════════ -->
+  <phase id="P1" name="val_loss=NaN Multi-Hypothesis Investigation" environment="local+cloud" blocked="false">
+    <description>
+      The sam3_hybrid smoke test on RTX 4090 produced val_loss=NaN. The KNOWN cause
+      is the val_interval sentinel (val_interval=3 > max_epochs=2 → skip all validation).
+      But this raises deeper questions: does the model actually produce valid predictions?
+      Are the loss values meaningful? Does training converge with real data?
+
+      This phase implements a systematic multi-hypothesis investigation with both
+      local code fixes and cloud GPU verification.
+    </description>
+
+    <hypotheses>
+      <hypothesis id="H1" name="Sentinel skip (known cause)" probability="0.90">
+        <description>
+          val_interval=3 > max_epochs=2 triggers _skip_all_val=True in trainer.py:583.
+          All validation epochs get EpochResult(loss=float("nan")). This is the direct
+          mechanism — NOT a model bug. Fix: create cloud smoke config with val_interval=1.
+        </description>
+        <test>Create smoke_sam3_hybrid_cloud.yaml with val_interval=1, run on RTX 4090</test>
+        <expected>val_loss is a real number (not NaN), validation runs without OOM</expected>
+      </hypothesis>
+
+      <hypothesis id="H2" name="FP16 encoder output causes NaN in loss" probability="0.15">
+        <description>
+          SAM3 encoder outputs FP16 features. If .float() cast is missing or incomplete
+          before loss computation, FP16 underflow/overflow could produce NaN loss values.
+          The .float() cast at line 205 fixes this for forward pass, but loss backward
+          might still encounter FP16 issues in gradient computation.
+        </description>
+        <test>Add gradient NaN check in trainer.py. Log gradient norm per epoch.</test>
+        <expected>If H2 is the cause, gradient norms will be NaN or Inf</expected>
+      </hypothesis>
+
+      <hypothesis id="H3" name="Model produces degenerate predictions" probability="0.10">
+        <description>
+          SAM3 hybrid's gated fusion might produce all-zeros or all-ones predictions
+          with the small smoke test dataset (2 volumes). The DynUNet branch may not
+          get meaningful gradients with only 2 training volumes. cbdice_cldice loss
+          with degenerate inputs could produce NaN.
+        </description>
+        <test>Log prediction stats (min, max, mean, std) per epoch. Check for degenerate
+          distributions (all same value, extreme values).</test>
+        <expected>If H3 is the cause, predictions will be near-constant</expected>
+      </hypothesis>
+
+      <hypothesis id="H4" name="Small dataset insufficient for SAM3 hybrid" probability="0.25">
+        <description>
+          The smoke test uses only 2 volumes for training. SAM3 hybrid has a frozen
+          648M-param ViT-32L encoder + trainable gated fusion + DynUNet-3D decoder.
+          With only 2 volumes, the model may not learn meaningful features, leading
+          to oscillating or diverging loss. This is NOT a code bug — it's expected
+          behavior with insufficient data.
+        </description>
+        <test>Run with full MiniVess dataset (47 train volumes, 3 folds) on cloud GPU.
+          Compare train_loss convergence: 2 vols vs 47 vols.</test>
+        <expected>If H4 is the cause, full dataset will show stable convergence</expected>
+      </hypothesis>
+
+      <hypothesis id="H5" name="Learning rate too high for frozen encoder" probability="0.10">
+        <description>
+          Default learning rate may be tuned for fully trainable models (DynUNet).
+          SAM3 hybrid has a frozen 648M-param encoder producing fixed features —
+          the trainable parameters are only the fusion layers + decoder. These may
+          need a lower learning rate to avoid gradient explosion in the small
+          trainable subnetwork.
+        </description>
+        <test>Run SAM3 hybrid with lr=1e-4 vs lr=1e-3 vs lr=5e-4. Compare stability.</test>
+        <expected>If H5 is the cause, lower LR will stabilize training</expected>
+      </hypothesis>
+
+      <hypothesis id="H6" name="cbdice_cldice loss incompatible with SAM3 output" probability="0.05">
+        <description>
+          cbdice_cldice computes centerline Dice which requires skeletonization of
+          predictions. If SAM3 hybrid predictions are not binary-like (sigmoid not
+          applied or threshold issue), skeletonization could fail and produce NaN.
+        </description>
+        <test>Run SAM3 hybrid with dice_ce loss instead of cbdice_cldice. Compare.</test>
+        <expected>If H6 is the cause, dice_ce will work while cbdice_cldice produces NaN</expected>
+      </hypothesis>
+
+      <hypothesis id="H7" name="Production validation will OOM on 8 GB GPU" probability="0.95">
+        <description>
+          For non-debug sam3_hybrid (max_epochs=100, val_interval=10), validation
+          WILL execute at epochs 0, 10, 20, etc. With 6.65 GB model + 5 GB inference
+          = 11.65 GB needed — OOM on 8 GB GPU. This is a production bug waiting
+          to happen. Need VRAM-aware validation gating, not just sentinel.
+        </description>
+        <test>Add VRAM-aware validation guard in train_flow.py. If available VRAM &lt;
+          required, warn and skip validation with explicit log message.</test>
+        <expected>Guard prevents OOM while logging clear warning</expected>
+      </hypothesis>
+    </hypotheses>
+
+    <task id="T1.1" name="Create cloud smoke config for sam3_hybrid"
+          priority="P0" estimated-iterations="1">
+      <description>
+        Create configs/experiment/smoke_sam3_hybrid_cloud.yaml with val_interval=1
+        and max_epochs=5 for cloud GPUs with ≥16 GB VRAM. Keep the existing
+        smoke_sam3_hybrid.yaml for 8 GB local GPUs (val_interval sentinel).
+      </description>
+      <files>
+        <file path="configs/experiment/smoke_sam3_hybrid_cloud.yaml" action="create" />
+      </files>
+      <tdd-spec>
+        <red>Test that cloud config file exists and has val_interval=1.</red>
+        <green>Create YAML config with val_interval=1, max_epochs=5, num_folds=1.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T1.2" name="VRAM-aware validation guard in train_flow.py"
+          priority="P0" estimated-iterations="2">
+      <description>
+        Add a VRAM-aware validation guard that reads the model profile YAML to
+        determine if validation is safe on the current GPU. Replace the fragile
+        val_interval sentinel with explicit VRAM budget check.
+
+        Logic:
+        1. Read model_overhead_mb from configs/model_profiles/{model}.yaml
+        2. Query available GPU VRAM via torch.cuda.get_device_properties()
+        3. If available VRAM &lt; model_overhead_mb + 2 GB headroom → skip validation
+        4. Log explicit warning: "Validation skipped: {available}MB &lt; {required}MB"
+        5. On cloud GPUs (≥16 GB), validation always runs
+
+        This replaces H7's production vulnerability with a proper guard.
+      </description>
+      <files>
+        <file path="src/minivess/orchestration/flows/train_flow.py" action="edit" />
+        <file path="tests/v2/unit/orchestration/test_vram_validation_guard.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that validation is skipped when mocked VRAM &lt; threshold.
+          Test that validation runs when mocked VRAM ≥ threshold.
+          Test that warning is logged when validation is skipped.
+          Test that val_interval is preserved when VRAM is sufficient.
+        </red>
+        <green>
+          Add _should_skip_validation(model_family, available_vram_mb) helper.
+          Read model profile YAML for model_overhead_mb.
+          Use torch.cuda.get_device_properties if available, else assume CPU.
+          Set val_interval = max_epochs + 1 only when VRAM is insufficient.
+        </green>
+      </tdd-spec>
+      <issue number="710" action="close" reason="VRAM-aware validation guard + cloud smoke config" />
+    </task>
+
+    <task id="T1.3" name="Add gradient and prediction diagnostics to trainer"
+          priority="P1" estimated-iterations="2">
+      <description>
+        Add lightweight diagnostic logging to trainer.py for debugging model
+        convergence issues. Log per-epoch:
+        - Gradient L2 norm (total)
+        - Prediction stats: min, max, mean, std of logits
+        - Whether any NaN/Inf values in gradients or predictions
+
+        These diagnostics help verify H2 (FP16 gradient NaN), H3 (degenerate
+        predictions), and H5 (LR too high). They are lightweight (&lt;1% overhead)
+        and valuable for all models, not just SAM3.
+      </description>
+      <files>
+        <file path="src/minivess/pipeline/trainer.py" action="edit" />
+        <file path="tests/v2/unit/pipeline/test_training_diagnostics.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that gradient norm is logged when diagnostics enabled.
+          Test that prediction stats are logged (min, max, mean, std).
+          Test that NaN detection raises warning (not error — training continues).
+          Test that diagnostics don't affect training results.
+        </red>
+        <green>
+          Add _log_diagnostics(model, predictions, epoch) method.
+          Call after each training step.
+          Use torch.nn.utils.clip_grad_norm_ result for gradient norm.
+          Log as MLflow metrics: grad_norm, pred_min, pred_max, pred_mean, pred_std.
+          Add NaN/Inf warning via logger.warning().
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T1.4" name="Create full-dataset SAM3 hybrid experiment config"
+          priority="P1" estimated-iterations="1"
+          blocked-by="T1.1,T1.2">
+      <description>
+        Create configs/experiment/sam3_hybrid_full.yaml for running SAM3 hybrid
+        with the full MiniVess dataset (47 train volumes, 3 folds, 50 epochs).
+        This tests H4 (small dataset insufficient). Must run on cloud GPU (≥24 GB).
+
+        Config: val_interval=5, max_epochs=50, num_folds=3, cbdice_cldice loss,
+        lr=1e-4 (conservative for frozen encoder), val_roi=(512,512,3).
+      </description>
+      <files>
+        <file path="configs/experiment/sam3_hybrid_full.yaml" action="create" />
+      </files>
+      <tdd-spec>
+        <red>Test that config file exists and is valid YAML with expected keys.</red>
+        <green>Create YAML config with full dataset settings.</green>
+      </tdd-spec>
+    </task>
+
+    <github-issue-group value="val-loss-nan-investigation">T1.1,T1.2,T1.3,T1.4</github-issue-group>
+  </phase>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       PHASE 2: Adapter Code Deduplication + Production Polish (/simplify)
+       ═══════════════════════════════════════════════════════════════════ -->
+  <phase id="P2" name="Adapter Code Deduplication + Production Polish" environment="local" blocked="false">
+    <description>
+      Apply /simplify to deduplicate code across SAM3 adapters and bring all
+      adapter code to production grade. Focus on DRY, clear error messages,
+      and consistent patterns across all model adapters.
+    </description>
+
+    <task id="T2.1" name="Extract shared checkpoint load/save to base.py"
+          priority="P2" estimated-iterations="2">
+      <description>
+        sam3_vanilla, sam3_topolora, and sam3_hybrid all have identical
+        load_checkpoint() and save_checkpoint() methods. Extract to
+        ModelAdapter base class (base.py). Keep adapter-specific overrides
+        possible via standard Python method override.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/base.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_vanilla.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_topolora.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_hybrid.py" action="edit" />
+        <file path="tests/v2/unit/adapters/test_base_checkpoint.py" action="create" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that ModelAdapter.save_checkpoint creates valid file.
+          Test that ModelAdapter.load_checkpoint restores state dict.
+          Test that FileNotFoundError raised for missing file.
+          Test that all 3 SAM3 adapters inherit the base implementation.
+        </red>
+        <green>
+          Move save_checkpoint/load_checkpoint to ModelAdapter base.
+          Include path.exists() check. Use _atomic_save from T0.5.
+          Remove duplicate methods from 3 SAM3 adapters.
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T2.2" name="Extract shared ONNX export wrapper to base.py"
+          priority="P2" estimated-iterations="1">
+      <description>
+        All 3 SAM3 adapters define identical _LogitsWrapper + export_onnx().
+        Extract to ModelAdapter base class. The wrapper converts
+        SegmentationOutput → raw Tensor for ONNX tracing.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/base.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_vanilla.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_topolora.py" action="edit" />
+        <file path="src/minivess/adapters/sam3_hybrid.py" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>No new tests needed — existing ONNX tests should still pass.</red>
+        <green>
+          Move _LogitsWrapper and export_onnx() to ModelAdapter base.
+          Remove duplicate code from 3 SAM3 adapters.
+          Run /simplify on the result.
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T2.3" name="Document FP16→FP32 casting rationale"
+          priority="P2" estimated-iterations="1">
+      <description>
+        All 3 SAM3 adapters have fpn_features.float() / sam_features.float()
+        but the rationale is undocumented. Add a clear comment in
+        sam3_backbone.py explaining:
+        - SAM3 loaded with torch_dtype=float16 (918 MB vs 1.8 GB FP32)
+        - All callers MUST cast to FP32 before trainable downstream modules
+        - This is separate from AMP — it's weight dtype, not autocast scope
+      </description>
+      <files>
+        <file path="src/minivess/adapters/sam3_backbone.py" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>No tests — documentation-only change.</red>
+        <green>Add docstring explaining FP16 loading and caller responsibility.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T2.4" name="Add logging to model_builder.py build_adapter()"
+          priority="P2" estimated-iterations="1">
+      <description>
+        build_adapter() successfully builds adapters silently. Add info-level
+        logging: "Building adapter: {family} — {model_name}". Helps debug
+        which model was built during training.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/model_builder.py" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>No new tests — add logging statement only.</red>
+        <green>Add logger.info() after successful adapter build.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T2.5" name="Run /simplify on all adapter code"
+          priority="P2" estimated-iterations="1"
+          blocked-by="T2.1,T2.2,T2.3,T2.4">
+      <description>
+        After deduplication, run /simplify on all adapter files to catch
+        remaining code quality issues: unused imports, inconsistent patterns,
+        over-engineering, missing type annotations.
+      </description>
+      <files>
+        <file path="src/minivess/adapters/" action="review" />
+      </files>
+      <tdd-spec>
+        <red>No new tests — review-only.</red>
+        <green>Apply all /simplify recommendations. Run make test-staging.</green>
+      </tdd-spec>
+    </task>
+
+    <github-issue-group value="adapter-deduplication">T2.1,T2.2,T2.3,T2.4,T2.5</github-issue-group>
+  </phase>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       PHASE 3: Issue Triage — Close Resolved, File New
+       ═══════════════════════════════════════════════════════════════════ -->
+  <phase id="P3" name="Issue Triage and Closure" environment="local" blocked="false">
+    <description>
+      Triage all open RunPod/dev issues. Close those already resolved by code.
+      File new issues discovered during code review. Update issue labels and
+      cross-references.
+    </description>
+
+    <task id="T3.1" name="Close already-resolved issues"
+          priority="P1" estimated-iterations="1">
+      <description>
+        The following issues are already resolved in code:
+        - #668 VesselFM RunPod launch — dev_runpod.yaml supports MODEL_FAMILY=vesselfm
+        - #689 MLflow env var resolution — launch_dev_runpod.py resolves correctly
+        - #692 Idle monitor — SkyPilot idle_minutes_to_autostop implemented
+
+        Close each with evidence comment citing specific code locations.
+      </description>
+      <files>None — GitHub CLI only</files>
+      <tdd-spec>
+        <red>N/A — issue management.</red>
+        <green>
+          gh issue close 668 --comment "..."
+          gh issue close 689 --comment "..."
+          gh issue close 692 --comment "..."
+        </green>
+      </tdd-spec>
+    </task>
+
+    <task id="T3.2" name="Update partially-resolved issues"
+          priority="P2" estimated-iterations="1">
+      <description>
+        Update issues that are partially resolved:
+        - #669 SkyPilot monitoring — ralph_monitor.py exists but no real-time polling
+        - #690 Makefile targets — Makefile has dev-gpu, Justfile lacks equivalents
+        - #703 Cloud GPU strategy — CLAUDE.md has partial coverage, needs dedicated section
+        - #670-#676 Cloud tests — test files exist but need model-specific verification
+
+        Add comments documenting what's done and what remains.
+      </description>
+      <files>None — GitHub CLI only</files>
+      <tdd-spec>
+        <red>N/A — issue management.</red>
+        <green>Add status comments to each issue with evidence.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T3.3" name="File new issues from code review findings"
+          priority="P1" estimated-iterations="1">
+      <description>
+        File new issues for findings from the code review that are NOT addressed
+        in this plan's Phase 0:
+        - VesselFM data leakage warning → should it be configurable severity?
+        - sam3_backbone torch_dtype=float16 is hardcoded → should be configurable
+        - Dimension ordering inconsistency between adapters (dim=4 vs dim=2)
+        - VRAM check doesn't account for data loader memory overhead
+      </description>
+      <files>None — GitHub CLI only</files>
+      <tdd-spec>
+        <red>N/A — issue management.</red>
+        <green>Create 2-4 new issues with proper METADATA blocks.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T3.4" name="Add Justfile dev-gpu recipes"
+          priority="P2" estimated-iterations="1">
+      <description>
+        Justfile lacks explicit dev-gpu equivalents that Makefile has.
+        Add: dev-gpu, dev-gpu-stop, dev-gpu-ssh, dev-gpu-heavy recipes
+        mirroring the Makefile targets.
+      </description>
+      <files>
+        <file path="justfile" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>No tests — infrastructure config.</red>
+        <green>Add 4 Justfile recipes matching Makefile dev-gpu* targets.</green>
+      </tdd-spec>
+    </task>
+
+    <github-issue-group value="issue-triage">T3.1,T3.2,T3.3,T3.4</github-issue-group>
+  </phase>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       PHASE 4: GCP Code Hardening
+       ═══════════════════════════════════════════════════════════════════ -->
+  <phase id="P4" name="GCP Code Hardening" environment="local" blocked="false">
+    <description>
+      Harden all GCP-related code: replace hardcoded values with env var
+      references, verify Pulumi stack structure, ensure SkyPilot GCP YAML
+      follows Docker-only mandate.
+    </description>
+
+    <task id="T4.1" name="Verify GCP Pulumi stack follows .env.example SSoT"
+          priority="P1" estimated-iterations="1">
+      <description>
+        Review deployment/pulumi/gcp/__main__.py against .env.example.
+        Verify all configurable values (project, region, bucket names) come
+        from Pulumi config (which reads from .env) not hardcoded strings.
+        Fix any violations of Rule #22.
+      </description>
+      <files>
+        <file path="deployment/pulumi/gcp/__main__.py" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that GCP Pulumi __main__.py has no hardcoded project IDs.
+          Test that all bucket names reference Pulumi config, not literals.
+        </red>
+        <green>Replace any hardcoded values with pulumi.Config() references.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T4.2" name="Verify SkyPilot GCP YAML uses Docker image_id"
+          priority="P0" estimated-iterations="1">
+      <description>
+        Per CLAUDE.md: SkyPilot YAML MUST use image_id: docker:&lt;registry&gt;/&lt;image&gt;.
+        Verify smoke_test_gcp.yaml follows this mandate. No bare VM setup
+        (apt-get, uv sync, git clone in setup:).
+      </description>
+      <files>
+        <file path="deployment/skypilot/smoke_test_gcp.yaml" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>
+          Test that smoke_test_gcp.yaml has image_id with docker: prefix.
+          Test that setup block has no apt-get, uv sync, or git clone.
+        </red>
+        <green>Ensure Docker-only execution pattern.</green>
+      </tdd-spec>
+    </task>
+
+    <task id="T4.3" name="Add cloud GPU strategy section to CLAUDE.md"
+          priority="P1" estimated-iterations="1">
+      <description>
+        Add a "Cloud GPU Strategy" subsection to CLAUDE.md documenting:
+        - RunPod: dev/prototyping (consumer GPUs, $0.44-0.88/hr)
+        - GCP: staging/prod (spot T4/L4/A100, same-region everything)
+        - Lambda Labs: rejected (no EU availability)
+        - Decision tree: which cloud for which use case
+        - Local hardware: RTX 2070 Super (8 GB) — dev only
+      </description>
+      <files>
+        <file path="CLAUDE.md" action="edit" />
+      </files>
+      <tdd-spec>
+        <red>No tests — documentation.</red>
+        <green>Add section with cloud provider comparison table.</green>
+      </tdd-spec>
+      <issue number="703" action="close" reason="Cloud GPU strategy added to CLAUDE.md" />
+    </task>
+
+    <github-issue-group value="gcp-hardening">T4.1,T4.2,T4.3</github-issue-group>
+  </phase>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       PHASE 5: Cloud Verification (BLOCKED — requires GPU credits)
+       ═══════════════════════════════════════════════════════════════════ -->
+  <phase id="P5" name="Cloud Verification" environment="cloud" blocked="true"
+         blocked-reason="Requires RunPod credits ($2-5) or GCP spot quota">
+    <description>
+      Run the val_loss=NaN hypothesis tests on cloud GPU. This phase CANNOT
+      be executed locally — it requires RTX 4090 or better.
+
+      Execution order:
+      1. Run smoke_sam3_hybrid_cloud.yaml (val_interval=1) — tests H1
+      2. If val_loss is real number → H1 confirmed, sentinel was the only issue
+      3. If val_loss is still NaN → investigate H2-H6 with diagnostic logging
+      4. Run sam3_hybrid_full.yaml (47 vols, 50 epochs) — tests H4
+      5. Document all results in model profiles and plan
+
+      Budget: ~$2-5 depending on how many hypotheses need testing.
+    </description>
+
+    <task id="T5.1" name="Run sam3_hybrid with val_interval=1 on RTX 4090"
+          priority="P0" estimated-iterations="1"
+          blocked-by="T1.1,T1.2,T1.3">
+      <description>
+        Deploy and run smoke_sam3_hybrid_cloud.yaml on RunPod RTX 4090.
+        Verify that val_loss is a real number. Record:
+        - val_loss values per epoch
+        - Gradient norms (from T1.3 diagnostics)
+        - Prediction stats (from T1.3 diagnostics)
+        - Total training time and VRAM peak
+      </description>
+      <files>None — cloud execution</files>
+      <expected-outcome>
+        val_loss is a real number (0.5-0.9 range), confirming H1 (sentinel skip).
+        If NaN persists, escalate to H2-H6 investigation.
+      </expected-outcome>
+    </task>
+
+    <task id="T5.2" name="Run sam3_hybrid full dataset (50 epochs) on RTX 4090"
+          priority="P1" estimated-iterations="1"
+          blocked-by="T1.4,T5.1">
+      <description>
+        Run sam3_hybrid_full.yaml (47 train volumes, 3 folds, 50 epochs).
+        Tests H4 (small dataset insufficient). Expected runtime: ~3-4 hours
+        on RTX 4090 (4.4s/epoch × 50 epochs × 3 folds ≈ 660s = 11 min training,
+        but validation adds ~15 min/fold). Cost: ~$3-4.
+
+        Record:
+        - Final val_loss and val_dice per fold
+        - Learning curve (loss vs epoch) for convergence analysis
+        - Compare against DynUNet baseline (val_dice ~0.74 from verified runs)
+      </description>
+      <files>None — cloud execution</files>
+      <expected-outcome>
+        SAM3 hybrid achieves val_dice comparable to or better than DynUNet (~0.74).
+        If significantly worse, the model architecture or loss configuration needs
+        attention (not a code bug).
+      </expected-outcome>
+    </task>
+
+    <task id="T5.3" name="Run VesselFM full dataset verification"
+          priority="P1" estimated-iterations="1"
+          blocked-by="T5.1">
+      <description>
+        Run VesselFM with full MiniVess dataset on RTX 4090 to establish
+        performance baseline. VesselFM was pre-trained on 17 datasets
+        (including MiniVess — data leakage!), so fine-tuning results
+        should be very strong but NOT usable for evaluation.
+
+        Key question: Does VesselFM converge faster than DynUNet due to
+        pre-training? (Expected: yes, significantly.)
+      </description>
+      <files>None — cloud execution</files>
+    </task>
+
+    <task id="T5.4" name="Document results and update model profiles"
+          priority="P1" estimated-iterations="1"
+          blocked-by="T5.1,T5.2,T5.3">
+      <description>
+        Update configs/model_profiles/ with verified full-dataset results.
+        Close #710 with evidence. Update adapters/CLAUDE.md VRAM tables.
+      </description>
+      <files>
+        <file path="configs/model_profiles/sam3_hybrid.yaml" action="edit" />
+        <file path="configs/model_profiles/vesselfm.yaml" action="edit" />
+        <file path="src/minivess/adapters/CLAUDE.md" action="edit" />
+      </files>
+    </task>
+
+    <github-issue-group value="cloud-verification">T5.1,T5.2,T5.3,T5.4</github-issue-group>
+  </phase>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       ISSUES
+       ═══════════════════════════════════════════════════════════════════ -->
+  <issues>
+    <!-- Close existing issues -->
+    <close number="668" reason="VesselFM RunPod launch — already implemented in dev_runpod.yaml + launch_dev_runpod.py" />
+    <close number="689" reason="MLflow env var resolution — fixed in launch_dev_runpod.py:109-123 + file-based MLflow on Network Volume" />
+    <close number="692" reason="Idle monitor — SkyPilot native idle_minutes_to_autostop in launch_dev_runpod.py" />
+
+    <!-- Create new issues from code review -->
+    <issue task="T0.1,T0.2,T0.3,T0.4"
+           title="P1: SAM3 adapter code review fixes — LoRA, validation, checkpoint error handling"
+           labels="models, P1-high, refactor" />
+    <issue task="T0.5"
+           title="P0: Atomic checkpoint writes for spot preemption safety"
+           labels="training, P0-critical, infrastructure"
+           relates-to="707" />
+    <issue task="T1.1,T1.2"
+           title="P0: VRAM-aware validation guard + cloud smoke config for sam3_hybrid"
+           labels="models, training, P0-critical"
+           relates-to="710" />
+    <issue task="T1.3"
+           title="P1: Add gradient/prediction diagnostics to trainer for model convergence debugging"
+           labels="training, P1-high, monitoring" />
+    <issue task="T2.1,T2.2,T2.3,T2.4,T2.5"
+           title="P2: Adapter code deduplication — checkpoint, ONNX export, FP16 docs"
+           labels="models, P2-medium, refactor" />
+    <issue task="T4.1,T4.2,T4.3"
+           title="P1: GCP code hardening — env vars, Docker mandate, CLAUDE.md strategy"
+           labels="infrastructure, P1-high"
+           relates-to="703" />
+  </issues>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       EXECUTION NOTES
+       ═══════════════════════════════════════════════════════════════════ -->
+  <execution-notes>
+    <note>Phases P0-P4 are LOCAL — no GPU credits needed. Execute immediately.</note>
+    <note>Phase P5 is BLOCKED on cloud credits. Execute when user confirms budget.</note>
+    <note>Use ralph-loop monitor for Phase P5 cloud execution (auto-diagnose failures).</note>
+    <note>Run /simplify after Phase P2 completes for final polish.</note>
+    <note>Commit after each phase with descriptive message.</note>
+    <note>Total estimated TDD iterations: P0=7, P1=6, P2=6, P3=4, P4=3 = 26 iterations</note>
+    <note>Session budget: 20 iterations max. Split P2+P3 into second session if needed.</note>
+    <note>
+      val_loss=NaN PRIORITY ORDER:
+      1. T1.1 (cloud config) + T1.2 (VRAM guard) — fixes the sentinel issue
+      2. T5.1 (cloud run with val_interval=1) — confirms H1
+      3. T1.3 (diagnostics) — enables H2-H6 investigation if H1 insufficient
+      4. T5.2 (full dataset) — tests H4 (data sufficiency)
+      Only proceed to steps 3-4 if step 2 shows val_loss is STILL NaN.
+    </note>
+  </execution-notes>
+
+</plan>

--- a/docs/planning/prod-staging-gcp-doublecheck-code-review.xml
+++ b/docs/planning/prod-staging-gcp-doublecheck-code-review.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plan name="Production/Staging GCP Double-Check &amp; Code Review"
+      version="1.0"
+      created="2026-03-15"
+      status="ready-for-execution"
+      priority="P0"
+      skills="self-learning-iterative-coder,ralph-loop,simplify"
+      branch="feat/skypilot-runpod-gpu-offloading">
+
+  <context>
+    <summary>
+      Final polishing of GCP infrastructure + SkyPilot training pipeline.
+      Verify all models train on GCP spot, artifact upload works with multipart,
+      spot preemption recovery works, and code is production-grade.
+      ALL tasks in this plan must be completed in this PR — no deferrals.
+    </summary>
+
+    <open-issues>
+      <!-- P0 — Must close in this PR -->
+      <issue id="702" title="Pulumi GCP stack" status="DEPLOYED (GCS+CloudSQL+GAR+CloudRun)" />
+      <issue id="687" title="Create GCP account + Pulumi stack" status="DONE" />
+      <issue id="684" title="Fix MLflow artifact upload — multipart" status="IN PROGRESS (testing signing SA)" />
+      <issue id="681" title="Switch to Docker-compatible SkyPilot providers" status="IN PROGRESS" />
+      <issue id="680" title="SAM3 FP16 dtype RuntimeError" status="OPEN — must fix for sam3_topolora" />
+
+      <!-- P1 — Should close in this PR -->
+      <issue id="707" title="Atomic checkpoint writes for spot safety" status="OPEN" />
+      <issue id="686" title="Spot checkpointing MOUNT_CACHED + auto-resume" status="OPEN" />
+      <issue id="685" title="Evaluate GCP all-in-one architecture" status="DONE (chosen GCP)" />
+      <issue id="689" title="Fix MLflow env var on RunPod pods" status="OPEN" />
+      <issue id="710" title="sam3_hybrid val_loss=NaN on RTX 4090" status="OPEN" />
+
+      <!-- P2 — Create issues, implement if time permits -->
+      <issue id="708" title="Hydra cloud config groups" status="OPEN" />
+      <issue id="709" title="AWS + Azure recipe YAMLs" status="OPEN — skip for now" />
+    </open-issues>
+
+    <gcp-infrastructure deployed="2026-03-15">
+      <component name="GCS Buckets" status="DEPLOYED">
+        minivess-mlops-mlflow-artifacts, minivess-mlops-dvc-data, minivess-mlops-checkpoints
+      </component>
+      <component name="Cloud SQL" status="DEPLOYED" ip="35.228.142.81" tier="db-g1-small" />
+      <component name="Artifact Registry" status="DEPLOYED"
+                 url="europe-north1-docker.pkg.dev/minivess-mlops/minivess" public="true" />
+      <component name="Cloud Run MLflow" status="DEPLOYED"
+                 url="https://minivess-mlflow-615852151588.europe-north1.run.app"
+                 sa="mlflow-server@minivess-mlops.iam.gserviceaccount.com"
+                 version="3.10.0" />
+      <component name="IAM" status="DEPLOYED"
+                 sa="skypilot-training@minivess-mlops.iam.gserviceaccount.com" />
+      <component name="GPU Quota" status="APPROVED" gpus_all_regions="1" />
+    </gcp-infrastructure>
+
+    <gpu-pricing-analysis>
+      <!-- Absolute cost per training job (DynUNet 3-fold x 100 epochs, MiniVess 70 volumes) -->
+      <!-- Baseline: ~24 hrs on RTX 2070 Super (local GPU) -->
+      <gpu name="T4" vram="16 GB" spot_rate="$0.14/hr" speedup_vs_2070="~1.0x"
+           wall_time="~24 hr" total_cost="$3.36" notes="Cheapest, same speed as 2070S" />
+      <gpu name="L4" vram="24 GB" spot_rate="$0.22/hr" speedup_vs_2070="~1.5x"
+           wall_time="~16 hr" total_cost="$3.52" notes="Ada Lovelace arch, 50% faster, only $0.16 more" />
+      <gpu name="A100-40GB" vram="40 GB" spot_rate="$1.15/hr" speedup_vs_2070="~2.5x"
+           wall_time="~10 hr" total_cost="$11.50" notes="3.4x more expensive for 2.4x faster" />
+      <gpu name="H100" vram="80 GB" spot_rate="$2.25/hr" speedup_vs_2070="~4.0x"
+           wall_time="~6 hr" total_cost="$13.50" notes="4x more expensive for 4x faster" />
+
+      <!-- For SAM3 smoke tests (2 epochs, 1 fold, 4 volumes) -->
+      <gpu name="T4" smoke_time="~4 min" smoke_cost="$0.01" />
+      <gpu name="L4" smoke_time="~2.5 min" smoke_cost="$0.01" />
+      <gpu name="A100" smoke_time="~1.5 min" smoke_cost="$0.03" />
+
+      <!-- L4 is the sweet spot: 50% faster than T4 for only 57% more $/hr -->
+      <!-- Total cost is nearly identical ($3.52 vs $3.36) due to shorter wall time -->
+    </gpu-pricing-analysis>
+  </context>
+
+  <!-- ================================================================== -->
+  <!-- PHASE A: Verify E2E Pipeline Works (CRITICAL)                      -->
+  <!-- ================================================================== -->
+  <phase id="A" name="E2E Pipeline Verification" skill="ralph-loop">
+
+    <task id="A1" title="Verify MLflow artifact upload with GCS multipart" priority="P0">
+      <description>
+        THE critical test: 910 MB .pth checkpoint must upload successfully via
+        multipart upload through Cloud Run MLflow to GCS.
+        Cloud Run SA: mlflow-server@ with serviceAccountTokenCreator (signing).
+        Client: MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD=true.
+      </description>
+      <success-criteria>
+        - Zero 413 errors (Cloud Run body size limit)
+        - Zero 500 errors (signing/GCS issues)
+        - Zero "Failed to upload" warnings
+        - Checkpoint visible in GCS bucket via gsutil
+        - MLflow UI shows artifacts for the run
+      </success-criteria>
+    </task>
+
+    <task id="A2" title="Train sam3_vanilla on GCP T4 spot E2E" depends="A1" priority="P0">
+      <description>Full E2E: GAR image pull → DVC data → train → MLflow metrics + artifacts</description>
+    </task>
+
+    <task id="A3" title="Train sam3_hybrid on GCP L4 spot" depends="A2" priority="P0">
+      <description>
+        sam3_hybrid needs ~7.5 GB VRAM → fits L4 (24 GB). Tests larger model.
+        Fixes #710 (val_loss=NaN) if it's a platform issue.
+      </description>
+    </task>
+
+    <task id="A4" title="Train dynunet on GCP T4 spot" depends="A2" priority="P1">
+      <description>DynUNet is the simplest model. Baseline for cost/time comparison.</description>
+    </task>
+  </phase>
+
+  <!-- ================================================================== -->
+  <!-- PHASE B: Spot Preemption Recovery                                  -->
+  <!-- ================================================================== -->
+  <phase id="B" name="Spot Preemption Recovery" skill="self-learning-iterative-coder" depends="A">
+
+    <task id="B1" title="Atomic checkpoint writes (R7)" priority="P0" issue="707">
+      <description>
+        trainer.py:802 does direct torch.save() — non-atomic. If spot preempted
+        during write, checkpoint is corrupt.
+        Fix: Write to temp file, then os.rename() to final path.
+      </description>
+      <files>src/minivess/pipeline/trainer.py</files>
+      <tests>tests/v2/unit/test_atomic_checkpoint.py</tests>
+    </task>
+
+    <task id="B2" title="Checkpoint SHA256 verification (R8)" depends="B1" priority="P0">
+      <description>
+        Write SHA256 hash after checkpoint save. Verify before torch.load() on resume.
+        Prevents loading corrupt partial checkpoints after spot preemption.
+      </description>
+      <files>src/minivess/pipeline/trainer.py, src/minivess/pipeline/checkpoint_integrity.py</files>
+      <tests>tests/v2/unit/test_checkpoint_integrity.py</tests>
+    </task>
+
+    <task id="B3" title="Wire check_resume_state_task into train_flow (R14)" depends="B2" priority="P0" issue="686">
+      <description>
+        check_resume_state_task at train_flow.py:169 is DEFINED but NEVER CALLED.
+        Wire it into the flow so training resumes from last checkpoint on spot recovery.
+      </description>
+      <files>src/minivess/orchestration/flows/train_flow.py</files>
+      <tests>tests/v2/unit/test_checkpoint_resume.py</tests>
+    </task>
+
+    <task id="B4" title="Add MOUNT_CACHED to SkyPilot YAML" depends="B3" priority="P0" issue="686">
+      <description>
+        Add GCS bucket mounting with MOUNT_CACHED for checkpoint persistence:
+        file_mounts: /checkpoints: name: minivess-checkpoints, mode: MOUNT_CACHED
+      </description>
+      <files>deployment/skypilot/smoke_test_gcp.yaml, deployment/skypilot/train_production.yaml</files>
+    </task>
+
+    <task id="B5" title="Spot preemption simulation test" depends="B4" priority="P1">
+      <description>
+        1. Launch 10-epoch training on GCP spot
+        2. After ~5 epochs: gcloud compute instances simulate-maintenance-event
+        3. Verify: SkyPilot recovers → checkpoint loaded → training resumes from epoch 5
+      </description>
+    </task>
+  </phase>
+
+  <!-- ================================================================== -->
+  <!-- PHASE C: Code Review + Simplification                              -->
+  <!-- ================================================================== -->
+  <phase id="C" name="Code Review + Production Polish" skill="simplify" depends="A">
+
+    <task id="C1" title="Review + simplify launch_smoke_test.py" priority="P1">
+      <description>
+        Multi-region launcher is 270 lines with duplicated env var loading.
+        Use /simplify to reduce complexity. Support --cloud gcp natively.
+      </description>
+      <files>scripts/launch_smoke_test.py</files>
+    </task>
+
+    <task id="C2" title="Deduplicate SkyPilot YAML setup/run blocks" priority="P1">
+      <description>
+        5 SkyPilot YAMLs have copy-pasted DVC pull + pre-flight check.
+        Extract to scripts/cloud_setup.sh and scripts/cloud_run.sh.
+      </description>
+    </task>
+
+    <task id="C3" title="Update .env.example with all GCP outputs" priority="P0">
+      <description>
+        Add MLFLOW_GCP_URI, complete GCS bucket vars, document Cloud Run URL.
+        Ensure all Pulumi outputs are documented.
+      </description>
+    </task>
+
+    <task id="C4" title="Close resolved GitHub issues" priority="P0">
+      <description>
+        Close: #702 (Pulumi GCP), #687 (GCP account), #685 (evaluate GCP), #681 (Docker providers).
+        Update: #684 (MLflow multipart — based on E2E test result).
+      </description>
+    </task>
+
+    <task id="C5" title="Update CLAUDE.md SkyPilot section for GCP" priority="P1">
+      <description>
+        Update SkyPilot provider table, add GCP as primary.
+        Document europe-west1 for T4/L4, europe-north1 for MLflow/GCS.
+        Add GPU pricing table.
+      </description>
+    </task>
+
+    <task id="C6" title="Pulumi GCP stack: fix Cloud Run in Pulumi code" priority="P1">
+      <description>
+        Cloud Run was deployed via gcloud CLI due to Pulumi API issues.
+        Fix the Pulumi code to use dict-based template properly so
+        `pulumi up` handles Cloud Run deployment, not manual gcloud.
+      </description>
+      <files>deployment/pulumi/gcp/__main__.py</files>
+    </task>
+  </phase>
+
+  <!-- ================================================================== -->
+  <!-- PHASE D: Multi-Model Verification                                  -->
+  <!-- ================================================================== -->
+  <phase id="D" name="Multi-Model GCP Training" skill="ralph-loop" depends="A,B">
+
+    <task id="D1" title="Fix SAM3 FP16 dtype issue (#680)" priority="P0" issue="680">
+      <description>
+        sam3_topolora broken by hardcoded FP16 dtype. Fix the adapter to
+        handle mixed precision correctly.
+      </description>
+    </task>
+
+    <task id="D2" title="Train all 5 models on GCP spot" depends="D1" priority="P1">
+      <description>
+        Verify: dynunet, sam3_vanilla, sam3_hybrid, sam3_topolora, vesselfm
+        all train successfully on GCP spot with artifact uploads.
+        Each model uses appropriate GPU (T4 for small, L4 for medium).
+      </description>
+    </task>
+  </phase>
+
+  <!-- ================================================================== -->
+  <!-- EXECUTION ORDER                                                    -->
+  <!-- ================================================================== -->
+  <execution-order>
+    <step>1. A1: Wait for definitive E2E test result (running now)</step>
+    <step>2. A2-A4: If A1 passes, run remaining models</step>
+    <step>3. B1-B2: Atomic checkpoint + SHA256 (TDD: test first)</step>
+    <step>4. B3-B4: Wire resume task + MOUNT_CACHED</step>
+    <step>5. C1-C3: Code review + simplification + .env update</step>
+    <step>6. C4-C6: Close issues + CLAUDE.md + Pulumi fix</step>
+    <step>7. D1-D2: Multi-model verification (if time permits)</step>
+    <step>8. B5: Spot preemption simulation (final validation)</step>
+    <step>9. Commit everything in semantically coherent chunks</step>
+  </execution-order>
+
+  <commit-plan>
+    <commit id="1" message="feat(infra): GCP Pulumi stack — GCS + Cloud SQL + GAR + Cloud Run MLflow">
+      <files>deployment/pulumi/gcp/*, deployment/docker/Dockerfile.mlflow-gcp</files>
+    </commit>
+    <commit id="2" message="feat(config): add MLFLOW_SERVER_VERSION, GCP vars to .env.example + tests">
+      <files>.env.example, tests/v2/unit/test_env_single_source.py, configs/cloud/gcp_quotas.yaml</files>
+    </commit>
+    <commit id="3" message="feat(skypilot): GCP spot training YAML + DVC init fix + multipart upload">
+      <files>deployment/skypilot/smoke_test_gcp.yaml, deployment/skypilot/*.yaml (dvc -f fix)</files>
+    </commit>
+    <commit id="4" message="feat(checkpoint): atomic writes + SHA256 verification for spot recovery">
+      <files>src/minivess/pipeline/trainer.py, src/minivess/pipeline/checkpoint_integrity.py, tests/*</files>
+    </commit>
+    <commit id="5" message="feat(training): wire check_resume_state_task + MOUNT_CACHED checkpointing">
+      <files>src/minivess/orchestration/flows/train_flow.py, deployment/skypilot/*.yaml</files>
+    </commit>
+    <commit id="6" message="docs(planning): GCP architecture plans, tutorials, metalearning">
+      <files>docs/planning/*.md, docs/planning/*.xml, .claude/metalearning/*.md</files>
+    </commit>
+    <commit id="7" message="refactor(launch): simplify launch_smoke_test.py + deduplicate YAML setup">
+      <files>scripts/launch_smoke_test.py, scripts/cloud_setup.sh</files>
+    </commit>
+  </commit-plan>
+</plan>

--- a/docs/planning/sam3-nan-loss-fix.md
+++ b/docs/planning/sam3-nan-loss-fix.md
@@ -1,0 +1,387 @@
+# SAM3 val_loss=NaN Root Cause Analysis & Fix Plan
+
+**Issue**: [#715](https://github.com/petteriTeikari/minivess-mlops/issues/715)
+**Date**: 2026-03-15
+**Status**: H1 CONFIRMED — sentinel NaN. AMP isolation in progress.
+**Models affected**: sam3_hybrid (confirmed), sam3_vanilla (untested)
+
+## Symptom
+
+sam3_hybrid training on RunPod RTX 4090 produces valid training metrics
+(`loss=0.661`, `dice=0.471`) but **val_loss=NaN** logged to MLflow.
+
+### Critical Discovery (2026-03-15, Ralph Loop Run 2)
+
+The val_loss=NaN was a **sentinel value, not an actual NaN from validation**:
+
+1. `debug: true` in config → `max_epochs=1` (code forced override, ignoring config's `max_epochs: 5`)
+2. `sam3_hybrid + debug` → `val_interval = max_epochs + 1 = 6` (skip validation sentinel)
+3. Since `val_interval(6) > max_epochs(1)` → `_skip_all_val = True`
+4. `val_result = EpochResult(loss=float("nan"))` — **default placeholder, not real NaN**
+5. Placeholder logged to MLflow as `val_loss: nan`
+
+**We never actually ran validation on sam3_hybrid** — not locally (OOM on 8 GB GPU),
+not on cloud (debug flag accidentally skipped it). The NaN was a phantom from the
+skip sentinel, not from sliding_window_inference or AMP.
+
+**Fix applied**: train_flow.py now reads `val_interval` and `max_epochs` from config
+when explicitly set, only falling back to model-based heuristics when not specified.
+
+```
+# RTX 4090 run (T5.1, 2026-03-15)
+Training: loss=0.795, dice=0.377  ← valid
+Validation: val_loss=NaN          ← broken
+```
+
+## Upstream Context: SAM3 IABCEMdetr Loss Bug
+
+SAM3's own training code has a **known NaN bug** in the `IABCEMdetr` loss function.
+While MinIVess does NOT use `IABCEMdetr` (we use `dice_ce`/`cbdice_cldice`), the
+upstream findings inform our numerical stability analysis.
+
+### Root Cause (SAM3 upstream)
+
+**Source**: [facebookresearch/sam3#289](https://github.com/facebookresearch/sam3/issues/289#issuecomment-3717103683)
+(yhy258, 2026-01-07), [facebookresearch/sam3#440](https://github.com/facebookresearch/sam3/issues/440)
+
+The `IABCEMdetr` loss function has `presence_gamma=0.0` as the Python `__init__` default:
+
+```python
+class IABCEMdetr(LossWithWeights):
+    def __init__(self, ..., presence_gamma=0.0, ...):  # <-- BUG: should be 2.0
+```
+
+When `gamma=0`, the Triton sigmoid focal loss backward pass computes:
+
+```python
+# _inner_focal_loss_bwd in sigmoid_focal_loss.py
+tmp = pow(1 - p_t, gamma - 1)     # gamma=0 → pow(1-p_t, -1) = 1/(1-p_t)
+# When p_t → 1.0 (correct prediction): tmp → ∞
+d_mod_factor = -gamma * d_pt * tmp  # = 0 * finite * ∞ = NaN (IEEE 754)
+```
+
+**IEEE 754**: `0 × ∞ = NaN`. This is a mathematical certainty, not a statistical fluke.
+
+**Fix**: Set `presence_gamma: 2.0` in loss config. The official SAM3 example YAMLs
+set `gamma: 2` for the main classification loss but **fail to set `presence_gamma`**,
+leaving it at the dangerous default of 0.0.
+
+### Why This Matters for MinIVess
+
+We don't use `IABCEMdetr`, but the same class of numerical instability — **FP16
+overflow/NaN in the frozen SAM3 encoder during validation** — may be our root cause.
+The SAM3 ViT-32L encoder runs in FP16 (for VRAM efficiency), and validation uses
+sliding window inference with different input distributions than training patches.
+
+## Multi-Hypothesis Decision Matrix
+
+| ID | Hypothesis | Likelihood | Evidence | Test | Fix Complexity |
+|----|-----------|------------|----------|------|----------------|
+| H1 | val_interval sentinel skip | **CONFIRMED** | `debug: true` forced `max_epochs=1`, `val_interval=6` → `_skip_all_val=True` → sentinel NaN logged. Validation never ran. | Fixed: config overrides code heuristics | Done |
+| H2 | FP16 overflow in encoder during validation | MEDIUM | Encoder NaN guard did NOT fire on RTX 4090 run (encoder output was clean). Still possible with different input distributions. | Rerun with actual validation enabled | Low |
+| H2b | AMP autocast + 3D DynUNet NaN | **HIGH** | MONAI maintainers confirm "AMP does not support very well with 3D operations" ([MONAI#4243](https://github.com/Project-MONAI/MONAI/discussions/4243)). sam3_hybrid fuses DynUNet-3D output under AMP. | Test with `mixed_precision: false` first | Low |
+| H3 | Sliding window edge patches produce degenerate inputs | MEDIUM | `sliding_window_inference` can produce small edge patches with near-zero/constant values | Log patch stats before encoder | Low |
+| H4 | AMP autocast + FP16 encoder interaction | MEDIUM | Training uses `autocast()`, encoder is already FP16; double-casting? | Test with `autocast(enabled=False)` during val | Low |
+| H5 | Decoder NaN from FP16→FP32 cast of extreme values | MEDIUM | FP16 max = 65504; encoder features could exceed this for some patches | Clamp encoder output before FP32 cast | Low |
+| H6 | Loss function on empty/degenerate predictions | LOW | `dice_ce` has `smooth_nr`/`smooth_dr` terms but edge cases exist | Log prediction stats before loss | Low |
+| H7 | MONAI `sliding_window_inference` overlap blending NaN | LOW | Overlap regions averaged; NaN in any window poisons the entire output | Test with `overlap=0.0` | Low |
+| H8 | FP16 vs BF16 encoder dtype mismatch | **MEDIUM-HIGH** | SAM3 HF model card uses `torch.bfloat16` in all examples. Our encoder uses `torch.float16`. If pretrained with BF16 activations, FP16 range (65504) may overflow. Same pattern as mT5 BF16→FP16 NaN. | Switch `sam3_backbone.py` to `torch.bfloat16` on Ampere+ GPUs | Low |
+
+### Hypothesis H2 Deep Dive (Most Likely)
+
+The SAM3 backbone runs in FP16 for VRAM efficiency:
+
+```python
+# sam3_backbone.py
+if self._frozen:
+    x = x.half()  # Cast to FP16
+    with torch.no_grad():
+        out = self.encoder(x)
+# Caller casts back to FP32
+```
+
+**Training path**: Small patches `(B=1, C=1, 32, 32, 3)` → FP16 encoder → FP32 decoder.
+Works fine because patches are small and well-conditioned.
+
+**Validation path**: Larger ROI `(512, 512, 3)` via `sliding_window_inference` → FP16
+encoder receives overlapping windows → some windows may have extreme intensity values →
+FP16 overflow (max 65504) → NaN features → NaN loss.
+
+**Key difference**: Validation uses `sliding_window_inference` which:
+1. Extracts overlapping windows from the full volume
+2. Each window passes through the encoder independently
+3. Results are stitched back together with overlap averaging
+4. If ANY window produces NaN, the entire output is poisoned
+
+### Hypothesis H3 Deep Dive
+
+`sliding_window_inference` at the boundaries can produce patches that are:
+- Partially zero-padded (if `mode="constant"`)
+- Very small (if the volume doesn't divide evenly)
+- Constant-valued (if the boundary region has no signal)
+
+The SAM3 ViT-32L encoder may not handle these degenerate inputs gracefully in FP16.
+
+## Proposed Fix Strategy (Updated 2026-03-15)
+
+### Phase 0: Config Fix — DONE
+
+**Problem**: `debug: true` forced `max_epochs=1` and skipped validation entirely.
+**Fix**: `train_flow.py` now reads `val_interval` and `max_epochs` from experiment config
+when explicitly set, only falling back to model-based heuristics otherwise. Also reads
+`mixed_precision` from config.
+
+### Phase 1: Diagnostic — NaN Guard Instrumentation (DONE)
+
+NaN detection added at three levels:
+1. `sam3_backbone.py:extract_features()` — NaN guard after encoder output
+2. `sam3_hybrid.py:forward()` — NaN guards after SAM features (FP16→FP32), DynUNet logits,
+   and fused logits (post-gate)
+3. `trainer.py:validate_epoch()` — NaN warning on non-finite avg_loss
+
+### Phase 2: AMP Isolation (Run 3, IN PROGRESS)
+
+**Test**: `mixed_precision: false` in `smoke_sam3_hybrid_cloud.yaml`.
+If val_loss is finite → AMP (H2b) is the root cause.
+If val_loss is still NaN → issue is elsewhere (fusion, loss, data).
+
+### Phase 3: Systematic Dtype Test Matrix
+
+If Phase 2 confirms AMP as the cause, run systematic dtype tests to pinpoint exactly
+which component fails under AMP:
+
+| Test | Encoder dtype | DynUNet dtype | AMP | Expected | Purpose |
+|------|---------------|---------------|-----|----------|---------|
+| T1 | FP16 (frozen) | FP32 | OFF | Finite | Baseline — no AMP |
+| T2 | FP16 (frozen) | FP32 | ON | NaN? | Current config — AMP interaction |
+| T3 | FP16 (frozen) | FP16 | OFF | NaN? | Is FP16 DynUNet the issue? |
+| T4 | BF16 (frozen) | FP32 | OFF | Finite? | BF16 encoder (no overflow) |
+| T5 | BF16 (frozen) | FP32 | ON | Finite? | BF16 encoder + AMP DynUNet |
+| T6 | FP16 (frozen) | FP32 | ON (val OFF) | Finite? | AMP for train only |
+| T7 | FP32 (frozen) | FP32 | OFF | Finite | Full FP32 (gold standard) |
+
+**Key dtype questions**:
+- **FP16 encoder → autocast context**: Does autocast try to cast FP16 inputs to FP16 again
+  (no-op) or does it interact with the trainable FP32 modules receiving the output?
+- **Instance norm in FP16**: DynUNet uses `norm_name="instance"`. Instance norm with
+  batch_size=1 has high variance-to-mean ratio which can overflow in FP16.
+- **BF16 vs FP16**: BF16 has same exponent range as FP32 (no overflow at 65504), but lower
+  mantissa precision. SAM3 encoder's LayerNorm/softmax may benefit from BF16 range.
+
+### Phase 4: Validation Pipeline Hardening (DONE)
+
+```python
+# trainer.py validate_epoch() — NaN guard
+if not math.isfinite(avg_loss):
+    logger.warning("Non-finite val_loss detected...")
+```
+
+### Phase 5: Structural Fixes (conditional on Phase 2-3 results)
+
+If AMP is confirmed as the root cause:
+
+**Option A: Disable AMP for validation only**
+```python
+# trainer.py — separate AMP policy for train vs val
+with autocast(device_type=..., enabled=self.config.mixed_precision and self.training):
+```
+
+**Option B: Disable AMP for sam3_hybrid entirely**
+```yaml
+# smoke_sam3_hybrid_cloud.yaml
+mixed_precision: false  # MONAI/PyTorch AMP + 3D known issue
+```
+
+**Option C: Switch frozen encoder to BF16** (if GPU supports it)
+```python
+# sam3_backbone.py — BF16 instead of FP16 for encoder
+if torch.cuda.is_bf16_supported():
+    x = x.to(torch.bfloat16)
+else:
+    x = x.half()
+```
+
+## Audit Trail: Run Log
+
+| Run | Date | Config Changes | Result | Diagnosis |
+|-----|------|---------------|--------|-----------|
+| 1 | 2026-03-15 01:59 | Original (debug=true) | val_loss=nan, train_loss=0.661 | Sentinel NaN — validation never ran (H1 CONFIRMED) |
+| 2 | 2026-03-15 02:14 | H1 fix: respect config val_interval/max_epochs, AMP OFF | **ALL FINITE**: ep0 val_loss=0.7264 train_loss=0.7534 val_dice=0.300; ep1 val_loss=0.7259 train_loss=0.7278 val_dice=0.301. Loss decreasing. 22 min/epoch, RTX 4090, 6150 MiB. 2/5 epochs done, 3 remaining. | **H1 CONFIRMED** — sentinel NaN. Zero NaN in 2 epochs of training+validation without AMP. |
+| 3 | (planned) | AMP ON if Run 2 succeeds | (planned) | Phase 3 — confirm AMP as root cause |
+| 4 | (planned) | BF16 encoder if Run 3 fails | (planned) | Phase 3 — dtype isolation |
+
+## Decision: Current Fix Order
+
+1. **Phase 0 (config fix)** — DONE. Config values respected.
+2. **Phase 2 (AMP isolation)** — IN PROGRESS. Run with `mixed_precision: false`.
+3. **Phase 3 (dtype test matrix)** — if Phase 2 succeeds, systematically re-enable AMP
+   with different dtype configurations.
+4. **Phase 5 (structural fix)** — permanent fix based on Phase 2-3 findings.
+
+## AMP + 3D Operations: Community Evidence
+
+### MONAI Community
+
+**[Project-MONAI/MONAI#4243](https://github.com/Project-MONAI/MONAI/discussions/4243)** — MONAI
+maintainer (nourmagde00 reply): *"AMP does not support very well with 3D operations. Sometimes
+turning on AMP would return NaN loss values, especially for SegResNet."* Recommended fix: disable
+AMP or switch architecture. This is directly relevant since sam3_hybrid uses DynUNet-3D under AMP.
+
+**[Project-MONAI/MONAI#2637](https://github.com/Project-MONAI/MONAI/discussions/2637)** — NaN
+traced to input data containing NaN after normalization of border crops: *"NaNs errors only
+triggered when amp was on"* but *"input already contained NaNs"* from *"normalization with a
+division by zero"* at volume borders. Fix: `SignalFillEmptyd` transform to cast NaN inputs to 0.
+Also: learning rate `1e-3` was too high — `1e-5` recommended. Redundant `Spacingd` + `Resized`
+caused double-resampling, increasing errors.
+
+**[Project-MONAI/tutorials#1637](https://github.com/Project-MONAI/tutorials/discussions/1637)** —
+Explains sliding window inference rationale but no NaN-specific content.
+
+### PyTorch Community
+
+**[PyTorch Discuss: "Loss is calculated as NaN when using AMP autocast"](https://discuss.pytorch.org/t/loss-is-calculated-as-nan-when-using-amp-autocast/186272)** —
+Binary segmentation U-Net with AMP: NaN loss at the first batch, before gradient updates.
+Debugging approach: "narrow down where the first invalid value is created by checking the loss,
+calculation as well as the intermediates of your forward pass." NaN occurred during forward pass
+(inside autocast), not during backpropagation.
+
+**[PyTorch Discuss: "FP16 gives NaN loss when using pre-trained model"](https://discuss.pytorch.org/t/fp16-gives-nan-loss-when-using-pre-trained-model/94133)** —
+Critical for our case (frozen pre-trained SAM3 encoder + trainable decoder):
+- **Overflow in intermediate activations** when fine-tuning well-trained models (not training from scratch)
+- **Deep supervision**: some branches produce `-inf`/NaN while others remain valid → aggregated loss is NaN
+- **Batch normalization** with very low standard deviation values can overflow in FP16
+- Fix: register **forward hooks** on each module to identify which layer first produces invalid values
+
+**[PyTorch Discuss: "Why my train and validation loss is as NaN"](https://discuss.pytorch.org/t/why-my-train-and-validation-loss-is-as-nan/206578)** —
+Custom activation functions passing negative values to `torch.log()` produce NaN. Fix: clip inputs
+before log operations. Also: validate that new training data doesn't contain NaN/Inf values.
+
+### Pretrained Model + Fine-Tuning NaN Patterns
+
+**[PyTorch Discuss: "Loss NaN when resuming from a pretrained model"](https://discuss.pytorch.org/t/loss-nan-when-resuming-from-a-pretrained-model/92234)** —
+NaN appears intermittently when fine-tuning pretrained models. LogSoftmax backward triggers
+the error. Debugging: check `abs().max()` on all parameters and use forward hooks to find
+first NaN layer. Issue is recurring and often unresolved — suggests environmental factors.
+
+**[MLX Examples #620: "NaN loss during LoRA fine-tuning"](https://github.com/ml-explore/mlx-examples/issues/620)** —
+LoRA fine-tuning of quantized Mistral 7B: loss spikes then goes NaN. Root cause: **FP16
+overflow** during training. Fix: quantize with FP32 instead of FP16, or reduce LoRA
+rank/alpha. Directly analogous to our frozen FP16 encoder scenario.
+
+**[HuggingFace Discuss: "Training loss 0.0, validation loss NaN"](https://discuss.huggingface.co/t/training-loss-0-0-validation-loss-nan/27950)** —
+mT5 fine-tuning: NaN val_loss. Root cause: **T5 was pretrained on TPU with BF16, but user
+trained with FP16**. FP16 range is [-65504, 65504] vs BF16's FP32-equivalent range. Fix:
+disable FP16 and use BF16 or FP32. **Directly relevant** — SAM3 may have been pretrained
+with BF16 (HuggingFace examples use `torch.bfloat16`).
+
+### SAM3 Official Dtype Recommendation (CRITICAL — Lost Institutional Knowledge)
+
+> **FUCKUP ALERT**: BF16 support was one of the original reasons for pursuing cloud GPUs!
+> The RTX 2070 Super (Turing) does NOT support BF16. Cloud GPUs (Ampere+: A100, RTX 3090,
+> RTX 4090) DO support BF16. Yet `sam3_backbone.py` was written with `torch.float16` for
+> the 2070 Super and **never updated when we moved to cloud**. Classic knowledge amnesia.
+> See: `.claude/metalearning/2026-03-15-sam3-bf16-fp16-fuckup.md`
+
+**[HuggingFace: facebook/sam3 Model Card](https://huggingface.co/facebook/sam3)** —
+SAM3's official HuggingFace examples consistently use **`torch.bfloat16`**, not `torch.float16`:
+```python
+model = Sam3VideoModel.from_pretrained("facebook/sam3").to(device, dtype=torch.bfloat16)
+```
+**Our `sam3_backbone.py:197` uses `torch.float16`** — this dtype mismatch with the pretrained
+weights could cause overflow (FP16 max = 65504 vs BF16's FP32-equivalent range of 3.4e38).
+If SAM3 was pretrained with BF16 activations, running inference in FP16 may truncate values
+beyond FP16 range → Inf → NaN. Same pattern as mT5 BF16→FP16 NaN.
+
+**Fix**: Auto-detect GPU capability and use BF16 when available:
+```python
+# sam3_backbone.py — should be:
+if torch.cuda.is_bf16_supported():
+    torch_dtype = torch.bfloat16  # Ampere+ (A100, RTX 3090/4090)
+else:
+    torch_dtype = torch.float16   # Turing fallback (RTX 2070 Super)
+```
+
+This is Phase 3 test T4/T5 in the dtype matrix.
+
+No SAM3-specific NaN discussions found on HuggingFace (167 discussions, mostly access requests).
+
+### General NaN Debugging (PyTorch Best Practices)
+
+**[Leyaa.ai: "How to fix NaN loss in PyTorch"](https://leyaa.ai/codefly/learn/pytorch/qna/how-to-fix-nan-loss-pytorch)** —
+Standard checklist: data validation (`torch.isnan/isinf`), epsilon before log/division,
+gradient clipping (`clip_grad_norm_`), monitor loss early, stop on first NaN.
+
+### Synthesis: Root Cause Likelihood for sam3_hybrid
+
+Given the community evidence, the most likely NaN sources for sam3_hybrid validation (in order):
+
+1. **H1 — Sentinel NaN (CONFIRMED)**: val_interval skip sentinel logged `float("nan")`
+   as placeholder. Validation never actually ran. Fixed by reading config values directly.
+
+2. **AMP + 3D DynUNet (H2b, HIGH)**: MONAI maintainers explicitly warn about this.
+   sam3_hybrid's DynUNet-3D runs under `autocast()` with instance norm + residual blocks.
+   Instance norm with small batch sizes can produce NaN in FP16.
+
+3. **FP16 vs BF16 encoder dtype (NEW, MEDIUM-HIGH)**: SAM3 HuggingFace examples use
+   `torch.bfloat16`, but our `sam3_backbone.py` uses `torch.float16`. If SAM3 was
+   pretrained with BF16 activations, FP16 inference may overflow (range 65504 vs 3.4e38).
+   Same pattern as mT5 BF16→FP16 NaN (HuggingFace discuss).
+
+4. **Frozen encoder + AMP interaction**: Pre-trained FP16 encoder outputs fed into
+   trainable FP32 modules under AMP autocast → potential dtype mismatches or double-casts.
+
+5. **Border patches from sliding_window_inference (H3)**: Normalization of near-zero
+   border regions → NaN input → poisoned output. Could be exacerbated by AMP.
+
+### Diagnostic Strategy (Updated)
+
+1. **Run 3 (current)**: `mixed_precision: false` — test WITHOUT AMP. If val_loss is finite,
+   AMP is the root cause. If still NaN, the issue is elsewhere.
+2. **If AMP is the cause**: Add `autocast(enabled=False)` specifically for validation (keep
+   AMP for training where it's working). Or disable AMP entirely for sam3_hybrid.
+3. **If NOT AMP**: Add forward hooks to sam3_hybrid's DynUNet layers to find the first NaN
+   source.
+
+## References
+
+- [yhy258 (2026). "IABCEMdetr presence_gamma=0 causes NaN." *GitHub facebookresearch/sam3#289*.](https://github.com/facebookresearch/sam3/issues/289#issuecomment-3717103683)
+- [WuJunxu (2026). "Loss is nan." *GitHub facebookresearch/sam3#440*.](https://github.com/facebookresearch/sam3/issues/440)
+- [Ravi et al. (2025). "SAM 3: Segment Anything in Images, Videos, and 3D." *arXiv:2511.16719*.](https://arxiv.org/abs/2511.16719)
+- [IEEE 754-2019. "Standard for Floating-Point Arithmetic." *IEEE*.](https://standards.ieee.org/ieee/754/6210/)
+- MinIVess Issue [#715](https://github.com/petteriTeikari/minivess-mlops/issues/715) — sam3_hybrid val_loss=NaN tracking
+- MinIVess Issue [#710](https://github.com/petteriTeikari/minivess-mlops/issues/710) — Original sam3_hybrid investigation
+- [MONAI Discussion #4243. "AMP + 3D operations NaN." *Project-MONAI/MONAI*.](https://github.com/Project-MONAI/MONAI/discussions/4243)
+- [MONAI Discussion #2637. "NaN errors with AMP and border crops." *Project-MONAI/MONAI*.](https://github.com/Project-MONAI/MONAI/discussions/2637)
+- [MONAI Tutorials Discussion #1637. "sliding_window_inference." *Project-MONAI/tutorials*.](https://github.com/Project-MONAI/tutorials/discussions/1637)
+- [PyTorch Discuss. "Loss is calculated as NaN when using AMP autocast."](https://discuss.pytorch.org/t/loss-is-calculated-as-nan-when-using-amp-autocast/186272)
+- [PyTorch Discuss. "FP16 gives NaN loss when using pre-trained model."](https://discuss.pytorch.org/t/fp16-gives-nan-loss-when-using-pre-trained-model/94133)
+- [PyTorch Discuss. "Why my train and validation loss is as NaN."](https://discuss.pytorch.org/t/why-my-train-and-validation-loss-is-as-nan/206578)
+- [PyTorch Discuss. "Loss NaN when resuming from a pretrained model."](https://discuss.pytorch.org/t/loss-nan-when-resuming-from-a-pretrained-model/92234)
+- [MLX Examples #620. "NaN loss during LoRA fine-tuning." *GitHub ml-explore/mlx-examples*.](https://github.com/ml-explore/mlx-examples/issues/620)
+- [HuggingFace Discuss. "Training loss 0.0, validation loss NaN." (mT5 BF16/FP16 mismatch).](https://discuss.huggingface.co/t/training-loss-0-0-validation-loss-nan/27950)
+- [HuggingFace Model Card. "facebook/sam3" — official BF16 dtype recommendation.](https://huggingface.co/facebook/sam3)
+- [Leyaa.ai. "How to fix NaN loss in PyTorch."](https://leyaa.ai/codefly/learn/pytorch/qna/how-to-fix-nan-loss-pytorch)
+
+## SAM3 Config Reference (from upstream YAML)
+
+The screenshot from the user shows SAM3's IABCEMdetr config:
+
+```yaml
+# SAM3 default loss config (NOT used by MinIVess)
+- _target_: sam3.train.loss.loss_fns.IABCEMdetr
+  weak_loss: False
+  weight_dict:
+    loss_ce: 20.0
+    presence_loss: 20.0
+  pos_weight: 10.0
+  alpha: 0.25
+  gamma: 2            # main focal gamma (OK)
+  use_presence: True
+  pos_focal: false
+  # presence_gamma: NOT SET → defaults to 0.0 → NaN!
+  # FIX: add presence_gamma: 2.0
+```
+
+**Note**: MinIVess uses its own loss registry (`dice_ce`, `cbdice_cldice`) — not
+`IABCEMdetr`. The upstream NaN bug is informative for understanding FP16/numerical
+stability but is not the direct cause of our val_loss=NaN.

--- a/src/minivess/adapters/CLAUDE.md
+++ b/src/minivess/adapters/CLAUDE.md
@@ -44,9 +44,28 @@ SDPA avoids materializing the full attention matrix, reducing encoder peak from
 model = Sam3Model.from_pretrained(
     "facebook/sam3",
     attn_implementation="sdpa",  # CRITICAL for 8 GB GPUs
-    torch_dtype=torch.float16,
+    torch_dtype=torch.float16,   # TODO: switch to bfloat16 on Ampere+ (see below)
 )
 ```
+
+### BF16 vs FP16 Encoder Dtype (CRITICAL — 2026-03-15)
+
+**SAM3's official HuggingFace examples use `torch.bfloat16`, not `torch.float16`.**
+
+Current `sam3_backbone.py` uses FP16 because it was written for RTX 2070 Super
+(Turing, no BF16 support). On cloud GPUs (Ampere+: A100, RTX 3090/4090) we
+SHOULD use BF16 for better numerical stability:
+
+- FP16 max = 65504. BF16 range = same as FP32 (3.4e38)
+- FP16 overflow → Inf → NaN in downstream operations
+- Known pattern: models pretrained with BF16 → NaN when run in FP16
+
+**Fix** (TODO): Auto-detect and prefer BF16:
+```python
+torch_dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+```
+
+See: `.claude/metalearning/2026-03-15-sam3-bf16-fp16-fuckup.md`
 
 ### MONAI Dimension Order (B, C, H, W, D) — NOT (B, C, D, H, W)
 

--- a/src/minivess/adapters/base.py
+++ b/src/minivess/adapters/base.py
@@ -164,7 +164,15 @@ class ModelAdapter(ABC, nn.Module):
         Default implementation loads into ``self.net`` (legacy) or into
         ``self`` (new format). Override for adapters that manage weights
         differently (e.g., LoRA, CommaAdapter).
+
+        Raises
+        ------
+        FileNotFoundError
+            If the checkpoint file does not exist.
         """
+        if not path.exists():
+            msg = f"No checkpoint found at {path}"
+            raise FileNotFoundError(msg)
         payload = torch.load(path, map_location="cpu", weights_only=True)
         if isinstance(payload, dict) and "model_state_dict" in payload:
             # New format: state_dict was produced by model.state_dict()
@@ -180,12 +188,13 @@ class ModelAdapter(ABC, nn.Module):
     def save_checkpoint(self, path: Path) -> None:
         """Save model weights to a checkpoint file.
 
-        Default implementation saves ``self.net`` state dict.
+        Saves the full adapter state dict wrapped in the standard
+        ``{"model_state_dict": ...}`` format. Works for both legacy
+        adapters (with ``self.net``) and SAM3-style adapters that
+        ARE the nn.Module.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
-        net = self.net
-        assert isinstance(net, nn.Module)
-        torch.save(net.state_dict(), path)
+        torch.save({"model_state_dict": self.state_dict()}, path)
 
     def trainable_parameters(self) -> int:
         """Return the count of trainable parameters.
@@ -200,32 +209,34 @@ class ModelAdapter(ABC, nn.Module):
     def export_onnx(self, path: Path, example_input: Tensor) -> None:
         """Export the model to ONNX format.
 
-        Uses the dynamo-based exporter (PyTorch 2.5+) with fallback
-        to the legacy TorchScript exporter for compatibility.
-        Override for adapters that need special export logic.
+        Wraps the adapter in a thin module that returns raw logits tensor
+        instead of SegmentationOutput (which ONNX tracing cannot handle).
+        Uses legacy TorchScript exporter with opset 17.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
-        net = self.net
-        assert isinstance(net, nn.Module)
-        net.eval()
+        self.eval()
 
+        adapter = self
+
+        class _LogitsWrapper(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.adapter = adapter
+
+            def forward(self, x: Tensor) -> Tensor:
+                result: Tensor = self.adapter(x).logits
+                return result
+
+        wrapper = _LogitsWrapper()
+        wrapper.eval()
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            try:
-                onnx_program = torch.onnx.export(
-                    net,
-                    (example_input,),
-                    dynamo=True,
-                )
-                if onnx_program is not None:
-                    onnx_program.save(str(path))
-            except Exception:
-                torch.onnx.export(
-                    net,
-                    (example_input,),
-                    str(path),
-                    input_names=["images"],
-                    output_names=["logits"],
-                    opset_version=17,
-                    dynamo=False,
-                )
+            torch.onnx.export(
+                wrapper,
+                (example_input,),
+                str(path),
+                input_names=["images"],
+                output_names=["logits"],
+                opset_version=17,
+                dynamo=False,
+            )

--- a/src/minivess/adapters/model_builder.py
+++ b/src/minivess/adapters/model_builder.py
@@ -273,7 +273,14 @@ def build_adapter(config: ModelConfig, **kwargs: Any) -> ModelAdapter:
         msg = f"Unsupported model family '{family}'. Available: {available}"
         raise ValueError(msg)
 
-    return builder(config, **kwargs)
+    adapter = builder(config, **kwargs)
+    logger.info(
+        "Built adapter: family=%s, name=%s, trainable=%d params",
+        family.value,
+        config.name,
+        adapter.trainable_parameters(),
+    )
+    return adapter
 
 
 def apply_wrappers(

--- a/src/minivess/adapters/sam3_backbone.py
+++ b/src/minivess/adapters/sam3_backbone.py
@@ -222,7 +222,20 @@ class Sam3Backbone(nn.Module):
         Handles grayscale→3ch expansion, resize to 1008×1008, and normalization.
         Converts MONAI MetaTensor to plain Tensor to avoid __torch_function__
         dispatch overhead inside the ViT encoder.
+
+        Raises
+        ------
+        ValueError
+            If input is not exactly 4D (B, C, H, W).
         """
+        if x.ndim != 4:
+            msg = (
+                f"Expected 4D input (B, C, H, W) for SAM3 preprocessing, "
+                f"got {x.ndim}D tensor with shape {tuple(x.shape)}. "
+                f"Slice 3D volumes before calling _preprocess()."
+            )
+            raise ValueError(msg)
+
         # Strip MONAI MetaTensor wrapper (saves memory + avoids dispatch overhead)
         if hasattr(x, "as_tensor"):
             x = x.as_tensor()
@@ -263,11 +276,23 @@ class Sam3Backbone(nn.Module):
         Feature tensor of shape (B, embed_dim, H_feat, W_feat).
         For the HF path the encoder includes the FPN neck, so the returned
         tensor is already at FPN dimension (256) rather than ViT dimension (1024).
+
+        Notes
+        -----
+        Includes a NaN/Inf guard on encoder output. The frozen encoder runs in
+        FP16 (half precision) for VRAM efficiency, which can produce NaN/Inf
+        via overflow in LayerNorm/softmax on certain input distributions
+        (e.g. boundary patches from sliding_window_inference during validation).
+        See docs/planning/sam3-nan-loss-fix.md (H2) and issue #715.
         """
         target_device = x.device
         x = self._preprocess(x)
         if self._frozen:
-            # Cast input to FP16 to match encoder weights (loaded in FP16)
+            # Cast input to FP16 to match encoder weights (loaded with
+            # torch_dtype=float16 in from_pretrained).  This halves encoder
+            # VRAM from ~2.2 GB to ~1.1 GB on ViT-32L (648M params).
+            # Callers must cast the returned features back to FP32 before
+            # passing them to trainable FP32 modules (decoder, fusion, LoRA).
             x = x.half()
             with torch.no_grad():
                 out = self.encoder(x)
@@ -284,6 +309,25 @@ class Sam3Backbone(nn.Module):
                 out = out.fpn_hidden_states[0]
             elif hasattr(out, "last_hidden_state"):
                 out = out.last_hidden_state
+
+        # NaN/Inf guard: FP16 encoder can overflow on certain inputs (boundary
+        # patches, extreme intensity values). Replace non-finite values with 0.0
+        # to prevent NaN from poisoning downstream loss computation.
+        # Zero features produce zero decoder output → valid (if uninformative) loss.
+        # See: docs/planning/sam3-nan-loss-fix.md, issue #715.
+        if not torch.isfinite(out).all():
+            nan_count = torch.isnan(out).sum().item()
+            inf_count = torch.isinf(out).sum().item()
+            total = out.numel()
+            logger.warning(
+                "NaN/Inf in SAM3 encoder output: %d NaN + %d Inf / %d total "
+                "(%.1f%%). Replacing with zeros to prevent loss poisoning.",
+                nan_count,
+                inf_count,
+                total,
+                100 * (nan_count + inf_count) / total,
+            )
+            out = torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
 
         result: Tensor = out.to(target_device)
         return result

--- a/src/minivess/adapters/sam3_hybrid.py
+++ b/src/minivess/adapters/sam3_hybrid.py
@@ -30,8 +30,6 @@ from minivess.adapters.base import AdapterConfigInfo, ModelAdapter, Segmentation
 from minivess.adapters.sam3_backbone import SAM3_FPN_DIM, SAM3_INPUT_SIZE, Sam3Backbone
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from minivess.config.models import ModelConfig
 
 logger = logging.getLogger(__name__)
@@ -200,11 +198,34 @@ class Sam3HybridAdapter(ModelAdapter):
         with torch.no_grad():
             sam_features = self._extract_sam_volume_features(images)
 
+        # SAM3 encoder runs in FP16 (torch_dtype=float16 in from_pretrained).
+        # Cast to FP32 before passing to trainable FP32 modules (axial_proj, fusion).
+        sam_features = sam_features.float()
+
+        # NaN diagnostic: check SAM features after FP16→FP32 cast
+        if not torch.isfinite(sam_features).all():
+            logger.warning(
+                "NaN/Inf in SAM features after FP32 cast: shape=%s",
+                tuple(sam_features.shape),
+            )
+            sam_features = torch.nan_to_num(
+                sam_features, nan=0.0, posinf=0.0, neginf=0.0
+            )
+
         # Axial smoothing of stacked 2D features
         sam_features = self.axial_proj(sam_features)
 
         # DynUNet forward (full 3D, trainable)
         logits: Tensor = self.dynunet(images)
+
+        # NaN diagnostic: check DynUNet output separately
+        if not torch.isfinite(logits).all():
+            logger.warning(
+                "NaN/Inf in DynUNet logits: shape=%s, nan=%d, inf=%d",
+                tuple(logits.shape),
+                torch.isnan(logits).sum().item(),
+                torch.isinf(logits).sum().item(),
+            )
 
         # Fuse SAM features at the output level
         # Resize SAM features to match logits spatial dims
@@ -230,6 +251,16 @@ class Sam3HybridAdapter(ModelAdapter):
         gate = torch.sigmoid(self.fusion.gate_alpha)
         logits = logits + gate * sam_projected
 
+        # Final NaN guard on fused logits
+        if not torch.isfinite(logits).all():
+            logger.warning(
+                "NaN/Inf in fused logits (after gate): nan=%d, inf=%d / %d total",
+                torch.isnan(logits).sum().item(),
+                torch.isinf(logits).sum().item(),
+                logits.numel(),
+            )
+            logits = torch.nan_to_num(logits, nan=0.0, posinf=0.0, neginf=0.0)
+
         return self._build_output(logits, "sam3_hybrid")
 
     def get_config(self) -> AdapterConfigInfo:
@@ -240,53 +271,6 @@ class Sam3HybridAdapter(ModelAdapter):
             input_size=SAM3_INPUT_SIZE,
             fusion="gated_residual",
         )
-
-    def save_checkpoint(self, path: Path) -> None:
-        """Save adapter state dict (no self.net dependency)."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        torch.save({"model_state_dict": self.state_dict()}, path)
-
-    def load_checkpoint(self, path: Path) -> None:
-        """Load adapter state dict (no self.net dependency)."""
-        payload = torch.load(path, map_location="cpu", weights_only=True)
-        if isinstance(payload, dict) and "model_state_dict" in payload:
-            self.load_state_dict(payload["model_state_dict"])
-        else:
-            self.load_state_dict(payload)
-
-    def export_onnx(self, path: Path, example_input: Tensor) -> None:
-        """Export adapter to ONNX (no self.net dependency).
-
-        Uses a thin wrapper to return raw logits tensor instead of
-        SegmentationOutput, which ONNX tracing cannot handle.
-        """
-        import warnings
-
-        path.parent.mkdir(parents=True, exist_ok=True)
-        self.eval()
-
-        class _LogitsWrapper(torch.nn.Module):
-            def __init__(self, adapter: Sam3HybridAdapter) -> None:
-                super().__init__()
-                self.adapter = adapter
-
-            def forward(self, x: Tensor) -> Tensor:
-                result: Tensor = self.adapter(x).logits
-                return result
-
-        wrapper = _LogitsWrapper(self)
-        wrapper.eval()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            torch.onnx.export(
-                wrapper,
-                (example_input,),
-                str(path),
-                input_names=["images"],
-                output_names=["logits"],
-                opset_version=17,
-                dynamo=False,
-            )
 
     def trainable_parameters(self) -> int:
         """Count trainable parameters (DynUNet + fusion)."""

--- a/src/minivess/adapters/sam3_topolora.py
+++ b/src/minivess/adapters/sam3_topolora.py
@@ -28,22 +28,22 @@ from minivess.adapters.sam3_backbone import SAM3_INPUT_SIZE, Sam3Backbone
 from minivess.adapters.sam3_decoder import Sam3MaskDecoder
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from minivess.config.models import ModelConfig
 
 logger = logging.getLogger(__name__)
 
 
 class LoRALinear(nn.Module):
-    """Low-Rank Adaptation layer wrapping an existing linear/conv layer.
+    """Low-Rank Adaptation layer wrapping an existing nn.Linear layer.
 
     Adds a low-rank decomposition: output = original(x) + (B @ A)(x) * scaling.
+    SAM3 ViT-32L is pure Linear (no Conv2d in the transformer blocks), so only
+    nn.Linear is supported. Conv2d LoRA would require a different decomposition.
 
     Parameters
     ----------
     original:
-        The original layer to wrap (nn.Linear or nn.Conv2d).
+        The original nn.Linear layer to wrap.
     rank:
         Rank of the low-rank decomposition.
     alpha:
@@ -60,6 +60,13 @@ class LoRALinear(nn.Module):
         dropout: float = 0.0,
     ) -> None:
         super().__init__()
+        if not isinstance(original, nn.Linear):
+            msg = (
+                f"LoRALinear only supports nn.Linear, got {type(original).__name__}. "
+                f"SAM3 ViT-32L uses only Linear layers in its transformer blocks."
+            )
+            raise TypeError(msg)
+
         self.original = original
         self.rank = rank
         self.scaling = alpha / rank
@@ -68,45 +75,39 @@ class LoRALinear(nn.Module):
         for param in original.parameters():
             param.requires_grad = False
 
-        # Determine dimensions from the original layer
-        if isinstance(original, nn.Linear):
-            in_features = original.in_features
-            out_features = original.out_features
-            self.lora_A = nn.Parameter(torch.randn(rank, in_features) * 0.01)
-            self.lora_B = nn.Parameter(torch.zeros(out_features, rank))
-        elif isinstance(original, nn.Conv2d):
-            in_channels = original.in_channels
-            out_channels = original.out_channels
-            self.lora_A = nn.Parameter(torch.randn(rank, in_channels) * 0.01)
-            self.lora_B = nn.Parameter(torch.zeros(out_channels, rank))
-        else:
-            msg = f"LoRALinear only supports Linear/Conv2d, got {type(original)}"
-            raise TypeError(msg)
+        in_features = original.in_features
+        out_features = original.out_features
+        self.lora_A = nn.Parameter(torch.randn(rank, in_features) * 0.01)
+        self.lora_B = nn.Parameter(torch.zeros(out_features, rank))
 
         self.lora_dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
-        self._is_conv = isinstance(original, nn.Conv2d)
+
+    @property
+    def weight(self) -> Tensor:
+        """Expose original layer's weight for HF code that accesses .weight.dtype."""
+        return self.original.weight
+
+    @property
+    def bias(self) -> Tensor | None:
+        """Expose original layer's bias for HF code that accesses .bias."""
+        return self.original.bias
 
     def forward(self, x: Tensor) -> Tensor:
-        """Forward pass: original(x) + LoRA(x)."""
+        """Forward pass: original(x) + LoRA(x).
+
+        Handles FP16/FP32 dtype mismatch: SAM3 encoder runs in FP16
+        but LoRA params are initialized in FP32. Cast input to match
+        LoRA dtype for matmul, then cast result back to input dtype.
+        """
         original_out: Tensor = self.original(x)
+        input_dtype = x.dtype
 
-        if self._is_conv:
-            # For Conv2d: use 1x1 conv via matrix multiply on output-spatial features
-            # Apply LoRA as a channel-mixing residual on the original output
-            b, c_out, h_out, w_out = original_out.shape
-            # Global average pool input channels → project through LoRA
-            x_avg = x.mean(dim=(2, 3))  # (B, C_in)
-            x_avg = self.lora_dropout(x_avg)
-            lora_out = (x_avg @ self.lora_A.T @ self.lora_B.T) * self.scaling
-            lora_out = lora_out.unsqueeze(-1).unsqueeze(-1)  # (B, C_out, 1, 1)
-            result: Tensor = original_out + lora_out
-            return result
-        else:
-            x_dropped = self.lora_dropout(x)
-            lora_out = (x_dropped @ self.lora_A.T @ self.lora_B.T) * self.scaling
+        x_dropped = self.lora_dropout(x).to(self.lora_A.dtype)
+        lora_out = (x_dropped @ self.lora_A.T @ self.lora_B.T) * self.scaling
+        lora_out = lora_out.to(input_dtype)
 
-        result_lin: Tensor = original_out + lora_out
-        return result_lin
+        result: Tensor = original_out + lora_out
+        return result
 
 
 def _apply_lora_to_encoder(
@@ -204,14 +205,17 @@ class Sam3TopoLoraAdapter(ModelAdapter):
         -------
         SegmentationOutput with 2-class predictions.
         """
-        b, c, d, h, w = images.shape
+        # MONAI dimension order: (B, C, H, W, D) — depth is LAST
+        b, c, h, w, d = images.shape
         slice_logits: list[Tensor] = []
 
         for z_idx in range(d):
-            slice_2d = images[:, :, z_idx, :, :]  # (B, C, H, W)
+            slice_2d = images[:, :, :, :, z_idx]  # (B, C, H, W)
 
             # FPN features (LoRA adapters are trainable, rest is frozen)
             fpn_features = self.backbone.extract_fpn_features(slice_2d)
+            # Cast FP16 encoder output to FP32 for decoder (#680)
+            fpn_features = fpn_features.float()
 
             # Decode to binary mask
             binary_logits = self.decoder(fpn_features)
@@ -240,53 +244,6 @@ class Sam3TopoLoraAdapter(ModelAdapter):
             lora_rank=self._lora_rank,
             lora_alpha=self._lora_alpha,
         )
-
-    def save_checkpoint(self, path: Path) -> None:
-        """Save adapter state dict (no self.net dependency)."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        torch.save({"model_state_dict": self.state_dict()}, path)
-
-    def load_checkpoint(self, path: Path) -> None:
-        """Load adapter state dict (no self.net dependency)."""
-        payload = torch.load(path, map_location="cpu", weights_only=True)
-        if isinstance(payload, dict) and "model_state_dict" in payload:
-            self.load_state_dict(payload["model_state_dict"])
-        else:
-            self.load_state_dict(payload)
-
-    def export_onnx(self, path: Path, example_input: Tensor) -> None:
-        """Export adapter to ONNX (no self.net dependency).
-
-        Uses a thin wrapper to return raw logits tensor instead of
-        SegmentationOutput, which ONNX tracing cannot handle.
-        """
-        import warnings
-
-        path.parent.mkdir(parents=True, exist_ok=True)
-        self.eval()
-
-        class _LogitsWrapper(torch.nn.Module):
-            def __init__(self, adapter: Sam3TopoLoraAdapter) -> None:
-                super().__init__()
-                self.adapter = adapter
-
-            def forward(self, x: Tensor) -> Tensor:
-                result: Tensor = self.adapter(x).logits
-                return result
-
-        wrapper = _LogitsWrapper(self)
-        wrapper.eval()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            torch.onnx.export(
-                wrapper,
-                (example_input,),
-                str(path),
-                input_names=["images"],
-                output_names=["logits"],
-                opset_version=17,
-                dynamo=False,
-            )
 
     def trainable_parameters(self) -> int:
         """Count trainable parameters (LoRA + decoder)."""

--- a/src/minivess/adapters/sam3_vanilla.py
+++ b/src/minivess/adapters/sam3_vanilla.py
@@ -34,8 +34,6 @@ from minivess.adapters.sam3_backbone import SAM3_INPUT_SIZE, Sam3Backbone
 from minivess.adapters.sam3_decoder import Sam3MaskDecoder
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from minivess.config.models import ModelConfig
 
 logger = logging.getLogger(__name__)
@@ -114,8 +112,8 @@ class Sam3VanillaAdapter(ModelAdapter):
             two_class = self.decoder.binary_to_2class(binary_logits)  # (B, 2, H, W)
             slice_logits.append(two_class)
 
-        # Stack along depth (last dim): (B, 2, H, W, D) — MONAI convention
-        logits_3d = torch.stack(slice_logits, dim=4)
+        # Stack along depth dim: (B, 2, D, H, W) — SegmentationOutput convention
+        logits_3d = torch.stack(slice_logits, dim=2)
 
         return self._build_output(logits_3d, "sam3_vanilla")
 
@@ -137,53 +135,6 @@ class Sam3VanillaAdapter(ModelAdapter):
             input_size=SAM3_INPUT_SIZE,
             encoder_frozen=True,
         )
-
-    def save_checkpoint(self, path: Path) -> None:
-        """Save adapter state dict (no self.net dependency)."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        torch.save({"model_state_dict": self.state_dict()}, path)
-
-    def load_checkpoint(self, path: Path) -> None:
-        """Load adapter state dict (no self.net dependency)."""
-        payload = torch.load(path, map_location="cpu", weights_only=True)
-        if isinstance(payload, dict) and "model_state_dict" in payload:
-            self.load_state_dict(payload["model_state_dict"])
-        else:
-            self.load_state_dict(payload)
-
-    def export_onnx(self, path: Path, example_input: Tensor) -> None:
-        """Export adapter to ONNX (no self.net dependency).
-
-        Uses a thin wrapper to return raw logits tensor instead of
-        SegmentationOutput, which ONNX tracing cannot handle.
-        """
-        import warnings
-
-        path.parent.mkdir(parents=True, exist_ok=True)
-        self.eval()
-
-        class _LogitsWrapper(torch.nn.Module):
-            def __init__(self, adapter: Sam3VanillaAdapter) -> None:
-                super().__init__()
-                self.adapter = adapter
-
-            def forward(self, x: Tensor) -> Tensor:
-                result: Tensor = self.adapter(x).logits
-                return result
-
-        wrapper = _LogitsWrapper(self)
-        wrapper.eval()
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            torch.onnx.export(
-                wrapper,
-                (example_input,),
-                str(path),
-                input_names=["images"],
-                output_names=["logits"],
-                opset_version=17,
-                dynamo=False,
-            )
 
     def trainable_parameters(self) -> int:
         """Count trainable parameters (decoder only)."""

--- a/src/minivess/pipeline/checkpoint_integrity.py
+++ b/src/minivess/pipeline/checkpoint_integrity.py
@@ -1,0 +1,114 @@
+"""SHA256 checkpoint integrity verification.
+
+Writes a .sha256 sidecar file alongside each checkpoint. On resume,
+verifies the checkpoint has not been corrupted (e.g., by spot preemption
+interrupting a write, or by storage-layer bit rot).
+
+Uses atomic writes for the sidecar itself — a corrupted sidecar is as
+dangerous as a corrupted checkpoint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+from minivess.pipeline.checkpoint_utils import atomic_text_write
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_HASH_BLOCK_SIZE = 1 << 16  # 64 KiB
+
+
+def compute_checkpoint_sha256(path: Path) -> str:
+    """Compute SHA256 hex digest of a checkpoint file.
+
+    Parameters
+    ----------
+    path:
+        Path to the checkpoint file.
+
+    Returns
+    -------
+    Lowercase hex digest string.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the checkpoint file does not exist.
+    """
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            block = f.read(_HASH_BLOCK_SIZE)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def write_sha256_sidecar(checkpoint_path: Path) -> Path:
+    """Write a .sha256 sidecar file alongside a checkpoint.
+
+    The sidecar file contains the hex digest of the checkpoint file.
+    Uses atomic write to prevent half-written sidecars.
+
+    Parameters
+    ----------
+    checkpoint_path:
+        Path to the checkpoint file (e.g., best_val_loss.pth).
+
+    Returns
+    -------
+    Path to the sidecar file (e.g., best_val_loss.pth.sha256).
+    """
+    digest = compute_checkpoint_sha256(checkpoint_path)
+    sidecar_path = checkpoint_path.with_suffix(checkpoint_path.suffix + ".sha256")
+    atomic_text_write(digest + "\n", sidecar_path)
+    logger.debug("SHA256 sidecar written: %s", sidecar_path)
+    return sidecar_path
+
+
+def verify_checkpoint_sha256(checkpoint_path: Path) -> bool:
+    """Verify a checkpoint against its SHA256 sidecar.
+
+    Parameters
+    ----------
+    checkpoint_path:
+        Path to the checkpoint file.
+
+    Returns
+    -------
+    True if the sidecar exists and the hash matches. False if the sidecar
+    is missing or the hash does not match.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the checkpoint file itself does not exist.
+    """
+    if not checkpoint_path.exists():
+        msg = f"Checkpoint file not found: {checkpoint_path}"
+        raise FileNotFoundError(msg)
+
+    sidecar_path = checkpoint_path.with_suffix(checkpoint_path.suffix + ".sha256")
+    if not sidecar_path.exists():
+        logger.warning("No SHA256 sidecar for %s", checkpoint_path)
+        return False
+
+    expected = sidecar_path.read_text(encoding="utf-8").strip()
+    actual = compute_checkpoint_sha256(checkpoint_path)
+    if actual != expected:
+        logger.error(
+            "SHA256 mismatch for %s: expected %s, got %s",
+            checkpoint_path,
+            expected,
+            actual,
+        )
+        return False
+
+    return True

--- a/src/minivess/pipeline/checkpoint_utils.py
+++ b/src/minivess/pipeline/checkpoint_utils.py
@@ -1,0 +1,74 @@
+"""Atomic checkpoint utilities for spot-preemption safety.
+
+Uses tmp file + os.replace() to ensure checkpoint files are never half-written.
+On spot instances (RunPod, AWS, GCP), preemption can interrupt a torch.save()
+mid-write, corrupting the checkpoint. The atomic pattern guarantees the file
+is either fully written or not present at all.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+def atomic_torch_save(obj: Any, path: Path) -> None:
+    """Save a PyTorch object atomically using tmp + os.replace().
+
+    Parameters
+    ----------
+    obj:
+        Object to save (state_dict, checkpoint dict, etc.).
+    path:
+        Destination file path.
+
+    Raises
+    ------
+    OSError
+        If the underlying torch.save fails (disk full, permissions, etc.).
+        The original file (if any) is preserved.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        torch.save(obj, tmp_path)
+        os.replace(tmp_path, path)
+    except BaseException:
+        # Clean up partial tmp file on any failure
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def atomic_text_write(content: str, path: Path, encoding: str = "utf-8") -> None:
+    """Write text atomically using tmp + os.replace().
+
+    Parameters
+    ----------
+    content:
+        Text content to write.
+    path:
+        Destination file path.
+    encoding:
+        Text encoding (default utf-8).
+
+    Raises
+    ------
+    OSError
+        If the write fails. The original file (if any) is preserved.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding=encoding) as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/minivess/pipeline/multi_metric_tracker.py
+++ b/src/minivess/pipeline/multi_metric_tracker.py
@@ -8,6 +8,9 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from minivess.pipeline.checkpoint_integrity import write_sha256_sidecar
+from minivess.pipeline.checkpoint_utils import atomic_torch_save
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -267,7 +270,8 @@ def save_metric_checkpoint(
     }
     if scaler_state_dict is not None:
         payload["scaler_state_dict"] = scaler_state_dict
-    torch.save(payload, path)
+    atomic_torch_save(payload, path)
+    write_sha256_sidecar(path)
 
 
 def load_metric_checkpoint(

--- a/tests/v2/unit/adapters/test_checkpoint_error_handling.py
+++ b/tests/v2/unit/adapters/test_checkpoint_error_handling.py
@@ -1,0 +1,59 @@
+"""Tests for checkpoint load error handling across SAM3 adapters.
+
+T0.3: Verify load_checkpoint raises FileNotFoundError for missing paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from minivess.adapters.base import ModelAdapter
+
+
+class _MinimalAdapter(ModelAdapter):
+    """Minimal adapter for testing base class checkpoint methods."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Linear(4, 2)
+
+    def forward(self, images: torch.Tensor, **kwargs):  # type: ignore[override]
+        return self.net(images)
+
+    def get_config(self):  # type: ignore[override]
+        return None
+
+    def trainable_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+class TestCheckpointErrorHandling:
+    """Checkpoint loading should fail clearly for missing files."""
+
+    def test_load_nonexistent_raises_file_not_found(self, tmp_path: Path) -> None:
+        """load_checkpoint raises FileNotFoundError for missing path."""
+        adapter = _MinimalAdapter()
+        missing = tmp_path / "nonexistent.pth"
+        with pytest.raises(FileNotFoundError, match="No checkpoint"):
+            adapter.load_checkpoint(missing)
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        """save_checkpoint + load_checkpoint roundtrip works."""
+        adapter = _MinimalAdapter()
+        path = tmp_path / "test.pth"
+        adapter.save_checkpoint(path)
+        assert path.exists()
+
+        adapter2 = _MinimalAdapter()
+        adapter2.load_checkpoint(path)
+
+    def test_save_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """save_checkpoint creates parent directories."""
+        adapter = _MinimalAdapter()
+        path = tmp_path / "deep" / "nested" / "checkpoint.pth"
+        adapter.save_checkpoint(path)
+        assert path.exists()

--- a/tests/v2/unit/adapters/test_sam3_backbone_validation.py
+++ b/tests/v2/unit/adapters/test_sam3_backbone_validation.py
@@ -1,0 +1,54 @@
+"""Tests for sam3_backbone input shape validation.
+
+T0.2: Verify _preprocess() rejects non-4D input with helpful error.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# Mock the SAM3 import since we don't have weights in test env
+_sam3_skip = pytest.mark.skipif(
+    True,  # Always skip actual backbone tests — need HF weights
+    reason="Sam3Backbone requires HF weights; test validation logic only",
+)
+
+
+class TestPreprocessInputValidation:
+    """_preprocess() should validate input is exactly 4D (B,C,H,W)."""
+
+    def test_rejects_3d_input(self) -> None:
+        """3D tensor (missing batch dim) should raise ValueError."""
+        from minivess.adapters.sam3_backbone import Sam3Backbone
+
+        # Create a mock backbone to test _preprocess without HF weights
+        backbone = object.__new__(Sam3Backbone)
+        backbone._input_size = 1008
+
+        x = torch.randn(3, 64, 64)  # 3D — wrong
+        with pytest.raises(ValueError, match="Expected 4D"):
+            backbone._preprocess(x)
+
+    def test_rejects_5d_input(self) -> None:
+        """5D tensor (full 3D volume) should raise ValueError."""
+        from minivess.adapters.sam3_backbone import Sam3Backbone
+
+        backbone = object.__new__(Sam3Backbone)
+        backbone._input_size = 1008
+
+        x = torch.randn(1, 1, 3, 64, 64)  # 5D — wrong
+        with pytest.raises(ValueError, match="Expected 4D"):
+            backbone._preprocess(x)
+
+    def test_accepts_4d_input(self) -> None:
+        """4D tensor (B,C,H,W) should pass validation."""
+        from minivess.adapters.sam3_backbone import Sam3Backbone
+
+        backbone = object.__new__(Sam3Backbone)
+        backbone._input_size = 64  # Small for test speed
+
+        x = torch.randn(1, 1, 64, 64)  # 4D — correct
+        # Should not raise — but will resize and normalize
+        result = backbone._preprocess(x)
+        assert result.ndim == 4

--- a/tests/v2/unit/adapters/test_sam3_dtype_consistency.py
+++ b/tests/v2/unit/adapters/test_sam3_dtype_consistency.py
@@ -1,0 +1,95 @@
+"""Tests for SAM3 FP16→FP32 dtype consistency (D1, issue #680).
+
+Verifies:
+1. All SAM3 adapters cast encoder FP16 output to FP32 before trainable modules
+2. No duplicate code blocks in sam3_backbone.py
+3. Backbone extract_features NaN guard is not duplicated
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+class TestAdapterFloatCasts:
+    """All SAM3 adapters must cast FP16 encoder output to FP32."""
+
+    @pytest.mark.parametrize(
+        "adapter_file",
+        ["sam3_vanilla.py", "sam3_hybrid.py", "sam3_topolora.py"],
+    )
+    def test_adapter_has_float_cast(self, adapter_file: str) -> None:
+        """Each adapter must call .float() on encoder features."""
+        src = Path(f"src/minivess/adapters/{adapter_file}")
+        content = src.read_text(encoding="utf-8")
+        assert ".float()" in content, (
+            f"{adapter_file} must cast FP16 encoder output to FP32 via .float()"
+        )
+
+    def test_backbone_loads_fp16(self) -> None:
+        """sam3_backbone.py must load encoder with torch_dtype=torch.float16."""
+        src = Path("src/minivess/adapters/sam3_backbone.py")
+        content = src.read_text(encoding="utf-8")
+        assert "torch.float16" in content or "float16" in content, (
+            "sam3_backbone.py must load encoder in FP16 for VRAM efficiency"
+        )
+
+    def test_backbone_has_half_cast(self) -> None:
+        """sam3_backbone.py must cast input to half() for frozen encoder."""
+        src = Path("src/minivess/adapters/sam3_backbone.py")
+        content = src.read_text(encoding="utf-8")
+        assert ".half()" in content, (
+            "sam3_backbone.py must cast input to FP16 to match frozen encoder weights"
+        )
+
+
+class TestNaNGuardNotDuplicated:
+    """NaN guard in extract_features must appear exactly once."""
+
+    def test_single_nan_guard_block(self) -> None:
+        """extract_features should have exactly ONE nan_to_num call."""
+        src = Path("src/minivess/adapters/sam3_backbone.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "extract_features":
+                # Count nan_to_num calls in the function body
+                nan_to_num_count = 0
+                for child in ast.walk(node):
+                    if (
+                        isinstance(child, ast.Call)
+                        and isinstance(child.func, ast.Attribute)
+                        and child.func.attr == "nan_to_num"
+                    ):
+                        nan_to_num_count += 1
+                assert nan_to_num_count == 1, (
+                    f"extract_features should have exactly 1 nan_to_num call, "
+                    f"found {nan_to_num_count} (duplicate detected)"
+                )
+                return
+        pytest.fail("extract_features not found in sam3_backbone.py")
+
+    def test_single_isfinite_check(self) -> None:
+        """extract_features should have exactly ONE isfinite check."""
+        src = Path("src/minivess/adapters/sam3_backbone.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "extract_features":
+                isfinite_count = 0
+                for child in ast.walk(node):
+                    if (
+                        isinstance(child, ast.Call)
+                        and isinstance(child.func, ast.Attribute)
+                        and child.func.attr == "isfinite"
+                    ):
+                        isfinite_count += 1
+                assert isfinite_count == 1, (
+                    f"extract_features should have exactly 1 isfinite check, "
+                    f"found {isfinite_count}"
+                )
+                return
+        pytest.fail("extract_features not found in sam3_backbone.py")

--- a/tests/v2/unit/adapters/test_sam3_nan_guard.py
+++ b/tests/v2/unit/adapters/test_sam3_nan_guard.py
@@ -1,0 +1,165 @@
+"""Tests for Sam3Backbone NaN guard in extract_features().
+
+Phase 1+2 from docs/planning/sam3-nan-loss-fix.md:
+  H2: FP16 overflow in encoder → NaN in features → NaN val_loss.
+  Fix: detect NaN after encoder, replace with 0.0 via nan_to_num.
+
+Issue: #715
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest  # noqa: TC002 — used at runtime for LogCaptureFixture
+import torch
+from torch import Tensor, nn
+
+
+class _NaNEncoder(nn.Module):
+    """Mock encoder that returns features with NaN values."""
+
+    def __init__(self, nan_fraction: float = 0.1) -> None:
+        super().__init__()
+        self._nan_fraction = nan_fraction
+
+    def forward(self, x: Tensor) -> Tensor:
+        out = torch.randn(x.shape[0], 256, 8, 8, dtype=x.dtype, device=x.device)
+        mask = torch.rand_like(out) < self._nan_fraction
+        out[mask] = float("nan")
+        return out
+
+
+class _AllNaNEncoder(nn.Module):
+    """Mock encoder that returns ALL NaN values (worst case)."""
+
+    def forward(self, x: Tensor) -> Tensor:
+        return torch.full(
+            (x.shape[0], 256, 8, 8), float("nan"), dtype=x.dtype, device=x.device
+        )
+
+
+class _CleanEncoder(nn.Module):
+    """Mock encoder that returns clean (finite) features."""
+
+    def forward(self, x: Tensor) -> Tensor:
+        return torch.randn(x.shape[0], 256, 8, 8, dtype=x.dtype, device=x.device)
+
+
+def _make_backbone(encoder: nn.Module, *, frozen: bool = True) -> nn.Module:
+    """Create a Sam3Backbone with a mock encoder (no HF weights needed).
+
+    Patches _load_sam3_encoder to return the mock encoder + Identity neck,
+    so the real __init__ runs but doesn't try to download SAM3 weights.
+    """
+    from minivess.adapters.sam3_backbone import Sam3Backbone
+    from minivess.config.models import ModelConfig
+
+    config = ModelConfig(
+        name="test_sam3",
+        family="sam3_vanilla",
+        in_channels=1,
+        out_channels=2,
+        architecture_params={"sam3_input_size": 64},
+    )
+
+    def _mock_load(self_: nn.Module) -> tuple[nn.Module, nn.Module]:
+        return encoder, nn.Identity()
+
+    with patch.object(Sam3Backbone, "_load_sam3_encoder", _mock_load):
+        backbone = Sam3Backbone(config=config, freeze=frozen, input_size=64)
+
+    return backbone
+
+
+class TestExtractFeaturesNaNGuard:
+    """extract_features() must return finite tensors even when encoder produces NaN."""
+
+    def test_nan_in_encoder_output_replaced_with_zeros(self) -> None:
+        """When encoder produces NaN, output should be finite (NaN → 0.0)."""
+        backbone = _make_backbone(_NaNEncoder(nan_fraction=0.3))
+        x = torch.randn(1, 1, 64, 64)
+
+        result = backbone.extract_features(x)
+
+        assert torch.isfinite(result).all(), (
+            f"Expected all-finite output but got {torch.isnan(result).sum()} NaN values"
+        )
+
+    def test_all_nan_encoder_output_replaced(self) -> None:
+        """Even if encoder returns all NaN, output should be all zeros."""
+        backbone = _make_backbone(_AllNaNEncoder())
+        x = torch.randn(1, 1, 64, 64)
+
+        result = backbone.extract_features(x)
+
+        assert torch.isfinite(result).all(), (
+            "All-NaN input should produce all-zero output"
+        )
+        assert (result == 0.0).all(), "NaN should be replaced with 0.0"
+
+    def test_clean_encoder_output_unchanged(self) -> None:
+        """When encoder produces clean output, it should pass through unchanged."""
+        backbone = _make_backbone(_CleanEncoder())
+        x = torch.randn(1, 1, 64, 64)
+
+        result = backbone.extract_features(x)
+
+        assert torch.isfinite(result).all(), "Clean output should remain finite"
+
+    def test_nan_detection_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When NaN is detected, a warning should be logged."""
+        backbone = _make_backbone(_NaNEncoder(nan_fraction=0.5))
+        x = torch.randn(1, 1, 64, 64)
+
+        with caplog.at_level(logging.WARNING, logger="minivess.adapters.sam3_backbone"):
+            backbone.extract_features(x)
+
+        assert any(
+            "NaN" in record.message and "encoder" in record.message.lower()
+            for record in caplog.records
+        ), f"Expected NaN warning in logs, got: {[r.message for r in caplog.records]}"
+
+    def test_clean_encoder_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When encoder output is clean, no NaN warning should be logged."""
+        backbone = _make_backbone(_CleanEncoder())
+        x = torch.randn(1, 1, 64, 64)
+
+        with caplog.at_level(logging.WARNING, logger="minivess.adapters.sam3_backbone"):
+            backbone.extract_features(x)
+
+        nan_warnings = [
+            r
+            for r in caplog.records
+            if "NaN" in r.message and "encoder" in r.message.lower()
+        ]
+        assert not nan_warnings, f"Unexpected NaN warning: {nan_warnings}"
+
+    def test_unfrozen_encoder_nan_guard_also_works(self) -> None:
+        """NaN guard should work for unfrozen encoder path too."""
+        backbone = _make_backbone(_NaNEncoder(nan_fraction=0.3), frozen=False)
+        x = torch.randn(1, 1, 64, 64)
+
+        result = backbone.extract_features(x)
+
+        assert torch.isfinite(result).all(), (
+            "Unfrozen path should also guard against NaN"
+        )
+
+    def test_inf_in_encoder_output_replaced(self) -> None:
+        """Inf values (FP16 overflow) should also be replaced."""
+
+        class _InfEncoder(nn.Module):
+            def forward(self, x: Tensor) -> Tensor:
+                out = torch.randn(x.shape[0], 256, 8, 8, dtype=x.dtype, device=x.device)
+                out[0, 0, 0, 0] = float("inf")
+                out[0, 1, 0, 0] = float("-inf")
+                return out
+
+        backbone = _make_backbone(_InfEncoder())
+        x = torch.randn(1, 1, 64, 64)
+
+        result = backbone.extract_features(x)
+
+        assert torch.isfinite(result).all(), "Inf values should be clamped to finite"

--- a/tests/v2/unit/adapters/test_sam3_topolora_lora.py
+++ b/tests/v2/unit/adapters/test_sam3_topolora_lora.py
@@ -1,0 +1,80 @@
+"""Tests for LoRALinear layer in sam3_topolora adapter.
+
+T0.1: Verify LoRA only supports nn.Linear, rejects Conv2d,
+and handles FP16→FP32 dtype casting correctly.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from minivess.adapters.sam3_topolora import LoRALinear
+
+
+class TestLoRALinearTypeValidation:
+    """LoRALinear should only support nn.Linear layers."""
+
+    def test_accepts_linear(self) -> None:
+        """LoRALinear wraps nn.Linear without error."""
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        assert lora.rank == 4
+
+    def test_rejects_conv2d(self) -> None:
+        """LoRALinear raises TypeError for Conv2d input."""
+        conv = nn.Conv2d(3, 16, kernel_size=3)
+        with pytest.raises(TypeError, match="only supports nn.Linear"):
+            LoRALinear(conv, rank=4)
+
+    def test_rejects_other_modules(self) -> None:
+        """LoRALinear raises TypeError for non-Linear modules."""
+        bn = nn.BatchNorm1d(64)
+        with pytest.raises(TypeError, match="only supports nn.Linear"):
+            LoRALinear(bn, rank=4)
+
+
+class TestLoRALinearForward:
+    """LoRALinear forward pass correctness."""
+
+    def test_forward_shape_preserved(self) -> None:
+        """Output shape matches original layer output."""
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        x = torch.randn(2, 64)
+        out = lora(x)
+        assert out.shape == (2, 32)
+
+    def test_forward_fp16_input(self) -> None:
+        """LoRA handles FP16 input with FP32 LoRA params."""
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4, alpha=8.0)
+        # Simulate SAM3 FP16 encoder output
+        x = torch.randn(2, 64, dtype=torch.float16)
+        linear.weight.data = linear.weight.data.half()
+        if linear.bias is not None:
+            linear.bias.data = linear.bias.data.half()
+        out = lora(x)
+        # Output should match input dtype
+        assert out.dtype == torch.float16
+
+    def test_original_frozen(self) -> None:
+        """Original layer parameters are frozen after wrapping."""
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4)
+        for param in lora.original.parameters():
+            assert not param.requires_grad
+
+    def test_lora_params_trainable(self) -> None:
+        """LoRA A and B matrices are trainable."""
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4)
+        assert lora.lora_A.requires_grad
+        assert lora.lora_B.requires_grad
+
+    def test_weight_property_delegates(self) -> None:
+        """weight property returns original layer's weight."""
+        linear = nn.Linear(64, 32)
+        lora = LoRALinear(linear, rank=4)
+        assert lora.weight is linear.weight

--- a/tests/v2/unit/adapters/test_sam3_vanilla_dim.py
+++ b/tests/v2/unit/adapters/test_sam3_vanilla_dim.py
@@ -1,0 +1,60 @@
+"""Tests for sam3_vanilla output dimension ordering.
+
+T0.4: Verify torch.stack uses dim=2 producing (B, C, D, H, W),
+matching SegmentationOutput convention.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+class TestVanillaDimOrdering:
+    """sam3_vanilla must stack slices along dim=2 (depth)."""
+
+    def test_stack_dim2_produces_correct_shape(self) -> None:
+        """torch.stack(slices, dim=2) produces (B, C, D, H, W)."""
+        # Simulate slice_logits: list of (B, 2, H, W) tensors
+        b, c, h, w, d = 1, 2, 64, 64, 3
+        slice_logits = [torch.randn(b, c, h, w) for _ in range(d)]
+
+        # dim=2 stacking: correct (B, C, D, H, W)
+        logits_3d = torch.stack(slice_logits, dim=2)
+        assert logits_3d.shape == (b, c, d, h, w), (
+            f"Expected (B,C,D,H,W)={(b, c, d, h, w)}, got {logits_3d.shape}"
+        )
+
+    def test_stack_dim4_is_wrong(self) -> None:
+        """torch.stack(slices, dim=4) produces (B, C, H, W, D) — wrong."""
+        b, c, h, w, d = 1, 2, 64, 64, 3
+        slice_logits = [torch.randn(b, c, h, w) for _ in range(d)]
+
+        logits_wrong = torch.stack(slice_logits, dim=4)
+        # This is (B, C, H, W, D) — depth is last, NOT matching convention
+        assert logits_wrong.shape == (b, c, h, w, d)
+        assert logits_wrong.shape != (b, c, d, h, w), (
+            "dim=4 should NOT produce (B,C,D,H,W)"
+        )
+
+    def test_vanilla_source_uses_dim2(self) -> None:
+        """sam3_vanilla.py source must contain 'dim=2' not 'dim=4' for stacking."""
+        import ast
+        from pathlib import Path
+
+        src = Path("src/minivess/adapters/sam3_vanilla.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                # Look for torch.stack calls
+                if isinstance(func, ast.Attribute) and func.attr == "stack":
+                    for kw in node.keywords:
+                        if kw.arg == "dim" and isinstance(kw.value, ast.Constant):
+                            dim_val: int = kw.value.value
+                            assert dim_val == 2, (
+                                f"torch.stack dim must be 2, got {dim_val}"
+                            )
+                            return
+        # If we get here, no torch.stack with dim= kwarg was found
+        # That's fine — the test for shape correctness above covers it

--- a/tests/v2/unit/configs/test_sam3_hybrid_configs.py
+++ b/tests/v2/unit/configs/test_sam3_hybrid_configs.py
@@ -1,0 +1,57 @@
+"""Tests for SAM3 hybrid experiment configs.
+
+T1.1 + T1.4: Verify cloud smoke and full-dataset configs exist and are valid.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_CONFIGS_DIR = Path("configs/experiment")
+
+
+class TestSam3HybridCloudConfig:
+    """T1.1: Cloud smoke config with validation enabled."""
+
+    def test_exists(self) -> None:
+        assert (_CONFIGS_DIR / "smoke_sam3_hybrid_cloud.yaml").exists()
+
+    def test_val_interval_is_1(self) -> None:
+        config = yaml.safe_load(
+            (_CONFIGS_DIR / "smoke_sam3_hybrid_cloud.yaml").read_text(encoding="utf-8")
+        )
+        assert config["val_interval"] == 1
+
+    def test_max_epochs_at_least_3(self) -> None:
+        config = yaml.safe_load(
+            (_CONFIGS_DIR / "smoke_sam3_hybrid_cloud.yaml").read_text(encoding="utf-8")
+        )
+        assert config["max_epochs"] >= 3
+
+
+class TestSam3HybridFullConfig:
+    """T1.4: Full-dataset config for convergence testing."""
+
+    def test_exists(self) -> None:
+        assert (_CONFIGS_DIR / "sam3_hybrid_full.yaml").exists()
+
+    def test_uses_full_splits(self) -> None:
+        config = yaml.safe_load(
+            (_CONFIGS_DIR / "sam3_hybrid_full.yaml").read_text(encoding="utf-8")
+        )
+        assert "3fold" in config.get("splits_file", "")
+
+    def test_has_reasonable_epochs(self) -> None:
+        config = yaml.safe_load(
+            (_CONFIGS_DIR / "sam3_hybrid_full.yaml").read_text(encoding="utf-8")
+        )
+        assert config["max_epochs"] >= 30
+
+    def test_uses_topology_loss(self) -> None:
+        config = yaml.safe_load(
+            (_CONFIGS_DIR / "sam3_hybrid_full.yaml").read_text(encoding="utf-8")
+        )
+        losses = config.get("losses", [])
+        assert "cbdice_cldice" in losses

--- a/tests/v2/unit/pipeline/test_atomic_checkpoint.py
+++ b/tests/v2/unit/pipeline/test_atomic_checkpoint.py
@@ -1,0 +1,322 @@
+"""Tests for atomic checkpoint writes.
+
+T0.5: Verify torch.save uses tmp + os.replace pattern for atomicity.
+B1: Verify wiring — save_metric_checkpoint and trainer epoch_latest use atomic saves.
+B2: SHA256 checkpoint integrity verification.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import torch
+
+
+class TestAtomicSave:
+    """_atomic_torch_save should write to tmp then atomically rename."""
+
+    def test_produces_valid_checkpoint(self, tmp_path: Path) -> None:
+        """Atomic save produces a loadable checkpoint file."""
+        from minivess.pipeline.checkpoint_utils import atomic_torch_save
+
+        state = {"weight": torch.randn(4, 4), "epoch": 10}
+        path = tmp_path / "model.pth"
+        atomic_torch_save(state, path)
+
+        assert path.exists()
+        loaded = torch.load(path, map_location="cpu", weights_only=False)
+        assert loaded["epoch"] == 10
+        assert torch.equal(loaded["weight"], state["weight"])
+
+    def test_no_tmp_file_after_success(self, tmp_path: Path) -> None:
+        """Temporary file is cleaned up after successful save."""
+        from minivess.pipeline.checkpoint_utils import atomic_torch_save
+
+        path = tmp_path / "model.pth"
+        atomic_torch_save({"x": 1}, path)
+
+        tmp_path_check = path.with_suffix(".pth.tmp")
+        assert not tmp_path_check.exists()
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """atomic_torch_save creates parent directories if missing."""
+        from minivess.pipeline.checkpoint_utils import atomic_torch_save
+
+        path = tmp_path / "deep" / "dir" / "model.pth"
+        atomic_torch_save({"x": 1}, path)
+        assert path.exists()
+
+    def test_original_preserved_on_failure(self, tmp_path: Path) -> None:
+        """If save fails, original file is untouched."""
+        from minivess.pipeline.checkpoint_utils import atomic_torch_save
+
+        path = tmp_path / "model.pth"
+        # Write original
+        atomic_torch_save({"epoch": 1}, path)
+
+        # Force a failure during save
+        with (
+            patch("torch.save", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            atomic_torch_save({"epoch": 2}, path)
+
+        # Original should still be readable with epoch=1
+        loaded = torch.load(path, map_location="cpu", weights_only=False)
+        assert loaded["epoch"] == 1
+
+
+class TestAtomicTextWrite:
+    """atomic_text_write should write text atomically (tmp + os.replace)."""
+
+    def test_produces_valid_text_file(self, tmp_path: Path) -> None:
+        """Atomic text write produces a readable file."""
+        from minivess.pipeline.checkpoint_utils import atomic_text_write
+
+        path = tmp_path / "state.yaml"
+        atomic_text_write("epoch: 5\n", path)
+
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == "epoch: 5\n"
+
+    def test_no_tmp_file_after_success(self, tmp_path: Path) -> None:
+        """Temporary file is cleaned up after successful write."""
+        from minivess.pipeline.checkpoint_utils import atomic_text_write
+
+        path = tmp_path / "state.yaml"
+        atomic_text_write("hello", path)
+
+        tmp_check = path.with_suffix(".yaml.tmp")
+        assert not tmp_check.exists()
+
+    def test_original_preserved_on_failure(self, tmp_path: Path) -> None:
+        """If write fails, original file is untouched."""
+        from minivess.pipeline.checkpoint_utils import atomic_text_write
+
+        path = tmp_path / "state.yaml"
+        atomic_text_write("epoch: 1\n", path)
+
+        with (
+            patch("builtins.open", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            atomic_text_write("epoch: 2\n", path)
+
+        assert path.read_text(encoding="utf-8") == "epoch: 1\n"
+
+
+class TestWiringSaveMetricCheckpoint:
+    """B1: save_metric_checkpoint must use atomic_torch_save, not raw torch.save."""
+
+    def test_save_metric_checkpoint_uses_atomic(self) -> None:
+        """AST check: save_metric_checkpoint calls atomic_torch_save, not torch.save."""
+        src = Path("src/minivess/pipeline/multi_metric_tracker.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.FunctionDef)
+                and node.name == "save_metric_checkpoint"
+            ):
+                body_src = ast.dump(node)
+                assert "atomic_torch_save" in body_src, (
+                    "save_metric_checkpoint must call atomic_torch_save"
+                )
+                # Ensure no raw torch.save call
+                for child in ast.walk(node):
+                    if (
+                        isinstance(child, ast.Call)
+                        and isinstance(child.func, ast.Attribute)
+                        and child.func.attr == "save"
+                        and isinstance(child.func.value, ast.Name)
+                        and child.func.value.id == "torch"
+                    ):
+                        pytest.fail(
+                            "save_metric_checkpoint must NOT call torch.save directly"
+                        )
+                return
+        pytest.fail("save_metric_checkpoint function not found")
+
+    def test_module_imports_atomic_torch_save(self) -> None:
+        """multi_metric_tracker.py must import atomic_torch_save."""
+        src = Path("src/minivess/pipeline/multi_metric_tracker.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and "checkpoint_utils" in node.module
+            ):
+                names = [alias.name for alias in node.names]
+                if "atomic_torch_save" in names:
+                    return
+        pytest.fail(
+            "multi_metric_tracker.py must import atomic_torch_save from checkpoint_utils"
+        )
+
+
+class TestWiringTrainerEpochLatest:
+    """B1: trainer.py epoch_latest saves must use atomic writes."""
+
+    def test_trainer_uses_atomic_for_epoch_pth(self) -> None:
+        """AST check: trainer.py uses atomic_torch_save for epoch_latest.pth."""
+        src = Path("src/minivess/pipeline/trainer.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        # Find the fit method and check for atomic_torch_save usage
+        found_atomic = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fit":
+                body_dump = ast.dump(node)
+                if "atomic_torch_save" in body_dump:
+                    found_atomic = True
+                break
+
+        assert found_atomic, (
+            "trainer.py fit() must use atomic_torch_save for epoch_latest.pth"
+        )
+
+    def test_trainer_uses_atomic_for_epoch_yaml(self) -> None:
+        """AST check: trainer.py uses atomic_text_write for epoch_latest.yaml."""
+        src = Path("src/minivess/pipeline/trainer.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        found_atomic = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fit":
+                body_dump = ast.dump(node)
+                if "atomic_text_write" in body_dump:
+                    found_atomic = True
+                break
+
+        assert found_atomic, (
+            "trainer.py fit() must use atomic_text_write for epoch_latest.yaml"
+        )
+
+    def test_trainer_imports_checkpoint_utils(self) -> None:
+        """trainer.py must import atomic_torch_save and atomic_text_write."""
+        src = Path("src/minivess/pipeline/trainer.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        imported_names: set[str] = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module
+                and "checkpoint_utils" in node.module
+            ):
+                for alias in node.names:
+                    imported_names.add(alias.name)
+
+        assert "atomic_torch_save" in imported_names, "Must import atomic_torch_save"
+        assert "atomic_text_write" in imported_names, "Must import atomic_text_write"
+
+
+class TestCheckpointSHA256:
+    """B2: SHA256 sidecar file written alongside checkpoints."""
+
+    def test_compute_sha256(self, tmp_path: Path) -> None:
+        """compute_checkpoint_sha256 returns correct SHA256 hex digest."""
+        from minivess.pipeline.checkpoint_integrity import compute_checkpoint_sha256
+
+        path = tmp_path / "test.pth"
+        content = b"test checkpoint data"
+        path.write_bytes(content)
+
+        expected = hashlib.sha256(content).hexdigest()
+        assert compute_checkpoint_sha256(path) == expected
+
+    def test_write_sha256_sidecar(self, tmp_path: Path) -> None:
+        """write_sha256_sidecar creates .sha256 file with correct hash."""
+        from minivess.pipeline.checkpoint_integrity import write_sha256_sidecar
+
+        path = tmp_path / "model.pth"
+        path.write_bytes(b"model weights")
+
+        write_sha256_sidecar(path)
+
+        sidecar = path.with_suffix(".pth.sha256")
+        assert sidecar.exists()
+        expected = hashlib.sha256(b"model weights").hexdigest()
+        assert sidecar.read_text(encoding="utf-8").strip() == expected
+
+    def test_verify_checkpoint_sha256_valid(self, tmp_path: Path) -> None:
+        """verify_checkpoint_sha256 returns True for uncorrupted file."""
+        from minivess.pipeline.checkpoint_integrity import (
+            verify_checkpoint_sha256,
+            write_sha256_sidecar,
+        )
+
+        path = tmp_path / "model.pth"
+        path.write_bytes(b"valid data")
+        write_sha256_sidecar(path)
+
+        assert verify_checkpoint_sha256(path) is True
+
+    def test_verify_checkpoint_sha256_corrupted(self, tmp_path: Path) -> None:
+        """verify_checkpoint_sha256 returns False for corrupted file."""
+        from minivess.pipeline.checkpoint_integrity import (
+            verify_checkpoint_sha256,
+            write_sha256_sidecar,
+        )
+
+        path = tmp_path / "model.pth"
+        path.write_bytes(b"original data")
+        write_sha256_sidecar(path)
+
+        # Corrupt the checkpoint
+        path.write_bytes(b"corrupted data")
+
+        assert verify_checkpoint_sha256(path) is False
+
+    def test_verify_missing_sidecar_returns_false(self, tmp_path: Path) -> None:
+        """verify_checkpoint_sha256 returns False when no .sha256 file exists."""
+        from minivess.pipeline.checkpoint_integrity import verify_checkpoint_sha256
+
+        path = tmp_path / "model.pth"
+        path.write_bytes(b"data")
+
+        assert verify_checkpoint_sha256(path) is False
+
+    def test_verify_missing_checkpoint_raises(self, tmp_path: Path) -> None:
+        """verify_checkpoint_sha256 raises FileNotFoundError for missing checkpoint."""
+        from minivess.pipeline.checkpoint_integrity import verify_checkpoint_sha256
+
+        path = tmp_path / "nonexistent.pth"
+        with pytest.raises(FileNotFoundError):
+            verify_checkpoint_sha256(path)
+
+    def test_save_metric_checkpoint_writes_sidecar(self, tmp_path: Path) -> None:
+        """save_metric_checkpoint writes .sha256 sidecar alongside .pth."""
+        from minivess.pipeline.multi_metric_tracker import (
+            MetricCheckpoint,
+            save_metric_checkpoint,
+        )
+
+        path = tmp_path / "best_val_loss.pth"
+        ckpt = MetricCheckpoint(
+            epoch=5,
+            metrics={"val_loss": 0.3},
+            metric_name="val_loss",
+            metric_value=0.3,
+            metric_direction="minimize",
+            train_loss=0.2,
+            val_loss=0.3,
+            wall_time_sec=120.0,
+            config_snapshot={"lr": 0.001},
+        )
+        save_metric_checkpoint(
+            path=path,
+            model_state_dict={"w": torch.randn(2, 2)},
+            optimizer_state_dict={"lr": 0.001},
+            scheduler_state_dict={"step": 1},
+            checkpoint=ckpt,
+        )
+
+        sidecar = path.with_suffix(".pth.sha256")
+        assert sidecar.exists(), "save_metric_checkpoint must write SHA256 sidecar"

--- a/tests/v2/unit/pipeline/test_checkpoint_resume.py
+++ b/tests/v2/unit/pipeline/test_checkpoint_resume.py
@@ -1,0 +1,139 @@
+"""Tests for checkpoint resume wiring (B3).
+
+Verifies:
+1. check_resume_state_task is called in train_one_fold_task
+2. trainer.fit() accepts start_epoch parameter
+3. Resume state loads model weights from epoch_latest.pth
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+import yaml
+
+
+class TestTrainerStartEpoch:
+    """trainer.fit() must accept a start_epoch parameter to resume training."""
+
+    def test_fit_accepts_start_epoch(self) -> None:
+        """AST check: fit() has a start_epoch parameter."""
+        src = Path("src/minivess/pipeline/trainer.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fit":
+                arg_names = [a.arg for a in node.args.args]
+                # Also check kwargs
+                kwonly = [a.arg for a in node.args.kwonlyargs]
+                all_args = arg_names + kwonly
+                assert "start_epoch" in all_args, (
+                    "fit() must accept a start_epoch parameter for spot recovery resume"
+                )
+                return
+        pytest.fail("fit() method not found in trainer.py")
+
+    def test_fit_start_epoch_defaults_to_zero(self) -> None:
+        """start_epoch should default to 0 (fresh training)."""
+        src = Path("src/minivess/pipeline/trainer.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fit":
+                for i, arg in enumerate(node.args.kwonlyargs):
+                    if arg.arg == "start_epoch":
+                        default = node.args.kw_defaults[i]
+                        assert isinstance(default, ast.Constant) and default.value == 0
+                        return
+                # Check positional args with defaults
+                n_args = len(node.args.args)
+                n_defaults = len(node.args.defaults)
+                for j, default in enumerate(node.args.defaults):
+                    arg_idx = n_args - n_defaults + j
+                    if node.args.args[arg_idx].arg == "start_epoch":
+                        assert isinstance(default, ast.Constant) and default.value == 0
+                        return
+                pytest.fail("start_epoch has no default or default is not 0")
+        pytest.fail("fit() method not found")
+
+    def test_fit_uses_start_epoch_in_range(self) -> None:
+        """fit() epoch loop must use start_epoch (not always range(0, max_epochs))."""
+        src = Path("src/minivess/pipeline/trainer.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "fit":
+                body_src = ast.dump(node)
+                assert "start_epoch" in body_src, (
+                    "fit() body must reference start_epoch in epoch loop"
+                )
+                return
+        pytest.fail("fit() method not found")
+
+
+class TestResumeWiring:
+    """check_resume_state_task must be wired into the fold training path."""
+
+    def test_train_one_fold_calls_check_resume(self) -> None:
+        """AST check: train_one_fold_task calls check_resume_state_task."""
+        src = Path("src/minivess/orchestration/flows/train_flow.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "train_one_fold_task":
+                body_dump = ast.dump(node)
+                assert "check_resume_state_task" in body_dump, (
+                    "train_one_fold_task must call check_resume_state_task"
+                )
+                return
+        pytest.fail("train_one_fold_task not found")
+
+    def test_train_one_fold_passes_start_epoch_to_fit(self) -> None:
+        """AST check: trainer.fit() is called with start_epoch kwarg."""
+        src = Path("src/minivess/orchestration/flows/train_flow.py")
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "train_one_fold_task":
+                for child in ast.walk(node):
+                    if isinstance(child, ast.Call):
+                        # Look for .fit(..., start_epoch=...) call
+                        for kw in child.keywords:
+                            if kw.arg == "start_epoch":
+                                return
+        pytest.fail("trainer.fit() must be called with start_epoch keyword argument")
+
+
+class TestResumeStateIntegration:
+    """Integration: epoch_latest.yaml + .pth enable resume."""
+
+    def test_resume_from_epoch_latest(self, tmp_path: Path) -> None:
+        """Write epoch_latest files, verify they can inform resume."""
+        checkpoint_dir = tmp_path / "fold_0"
+        checkpoint_dir.mkdir()
+
+        # Write epoch_latest.yaml
+        state = {
+            "epoch": 5,
+            "fold": 0,
+            "mlflow_run_id": None,
+            "best_val_loss": 0.42,
+            "timestamp": "2026-03-15T01:00:00+00:00",
+        }
+        yaml_path = checkpoint_dir / "epoch_latest.yaml"
+        yaml_path.write_text(yaml.dump(state), encoding="utf-8")
+
+        # Write epoch_latest.pth
+        model_state = {"layer.weight": torch.randn(4, 4)}
+        pth_path = checkpoint_dir / "epoch_latest.pth"
+        torch.save(model_state, pth_path)
+
+        # Verify can load
+        loaded_state = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert loaded_state["epoch"] == 5
+
+        loaded_weights = torch.load(pth_path, map_location="cpu", weights_only=True)
+        assert "layer.weight" in loaded_weights

--- a/tests/v2/unit/pipeline/test_trainer_nan_handling.py
+++ b/tests/v2/unit/pipeline/test_trainer_nan_handling.py
@@ -1,0 +1,157 @@
+"""Tests for SegmentationTrainer NaN handling in validation.
+
+Phase 4 from docs/planning/sam3-nan-loss-fix.md:
+  Validation pipeline hardening — validate_epoch should log NaN but not crash.
+  Training loss NaN should still hard-fail (existing behavior preserved).
+
+Issue: #715
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import pytest
+import torch
+from torch import Tensor, nn
+
+from minivess.adapters.base import ModelAdapter, SegmentationOutput
+from minivess.config.models import TrainingConfig
+from minivess.pipeline.trainer import SegmentationTrainer
+
+
+class _DummyAdapter(ModelAdapter):
+    """Minimal adapter for testing trainer NaN handling."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Linear(4, 2)
+
+    def forward(self, images: Tensor, **kwargs: Any) -> SegmentationOutput:
+        b = images.shape[0]
+        logits = torch.randn(b, 2, 4, 4, 3)
+        return self._build_output(logits, "dummy")
+
+    def get_config(self) -> Any:
+        return self._build_config(variant="dummy")
+
+    def trainable_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+class _NaNCriterion(nn.Module):
+    """Loss function that always returns NaN."""
+
+    def forward(self, pred: Tensor, target: Tensor) -> Tensor:
+        return torch.tensor(float("nan"), device=pred.device)
+
+
+class _FiniteCriterion(nn.Module):
+    """Loss function that returns a finite value."""
+
+    def forward(self, pred: Tensor, target: Tensor) -> Tensor:
+        return torch.tensor(0.5, device=pred.device)
+
+
+def _make_val_batch() -> list[dict[str, Tensor]]:
+    """Create a minimal validation batch."""
+    return [
+        {
+            "image": torch.randn(1, 1, 4, 4, 3),
+            "label": torch.randint(0, 2, (1, 1, 4, 4, 3)).float(),
+        }
+    ]
+
+
+def _make_trainer(
+    criterion: nn.Module,
+    *,
+    mixed_precision: bool = False,
+) -> SegmentationTrainer:
+    """Create a SegmentationTrainer with injected criterion."""
+    import os
+
+    os.environ.setdefault("MINIVESS_ALLOW_HOST", "1")
+    os.environ.setdefault("PREFECT_DISABLED", "1")
+
+    config = TrainingConfig(
+        max_epochs=2,
+        batch_size=1,
+        learning_rate=1e-4,
+        mixed_precision=mixed_precision,
+        warmup_epochs=0,
+        val_interval=1,
+    )
+    model = _DummyAdapter()
+
+    return SegmentationTrainer(
+        model=model,
+        config=config,
+        criterion=criterion,
+        device="cpu",
+    )
+
+
+class TestValidateEpochNaNHandling:
+    """validate_epoch should handle NaN loss gracefully."""
+
+    def test_nan_loss_does_not_raise(self) -> None:
+        """validate_epoch should return NaN loss, not raise an exception."""
+        trainer = _make_trainer(_NaNCriterion())
+        loader = _make_val_batch()
+
+        # Should NOT raise — NaN in validation is logged, not fatal
+        result = trainer.validate_epoch(loader)
+
+        assert math.isnan(result.loss), f"Expected NaN loss, got {result.loss}"
+
+    def test_nan_loss_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """validate_epoch should log a warning when val_loss is NaN."""
+        trainer = _make_trainer(_NaNCriterion())
+        loader = _make_val_batch()
+
+        with caplog.at_level(logging.WARNING, logger="minivess.pipeline.trainer"):
+            trainer.validate_epoch(loader)
+
+        assert any(
+            "non-finite" in record.message.lower() or "nan" in record.message.lower()
+            for record in caplog.records
+        ), f"Expected NaN warning, got: {[r.message for r in caplog.records]}"
+
+    def test_finite_loss_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """validate_epoch should not warn when loss is finite."""
+        trainer = _make_trainer(_FiniteCriterion())
+        loader = _make_val_batch()
+
+        with caplog.at_level(logging.WARNING, logger="minivess.pipeline.trainer"):
+            trainer.validate_epoch(loader)
+
+        nan_warnings = [
+            r
+            for r in caplog.records
+            if "non-finite" in r.message.lower() or "nan" in r.message.lower()
+        ]
+        assert not nan_warnings, f"Unexpected NaN warning: {nan_warnings}"
+
+    def test_finite_loss_returns_correct_value(self) -> None:
+        """validate_epoch should return the correct finite loss."""
+        trainer = _make_trainer(_FiniteCriterion())
+        loader = _make_val_batch()
+
+        result = trainer.validate_epoch(loader)
+
+        assert abs(result.loss - 0.5) < 1e-5, f"Expected 0.5 loss, got {result.loss}"
+
+
+class TestTrainEpochNaNStillFails:
+    """Training NaN should still hard-fail (preserve existing guard)."""
+
+    def test_train_nan_loss_raises(self) -> None:
+        """train_epoch should raise ValueError on NaN training loss."""
+        trainer = _make_trainer(_NaNCriterion())
+        loader = _make_val_batch()  # Same format works for train
+
+        with pytest.raises(ValueError, match="Non-finite loss"):
+            trainer.train_epoch(loader)

--- a/tests/v2/unit/pipeline/test_training_diagnostics.py
+++ b/tests/v2/unit/pipeline/test_training_diagnostics.py
@@ -1,0 +1,72 @@
+"""Tests for training diagnostics logging.
+
+T1.3: Verify gradient norm and prediction stats are computed correctly.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class TestGradientDiagnostics:
+    """Gradient diagnostics should compute norm and detect NaN."""
+
+    def test_compute_gradient_norm(self) -> None:
+        """compute_gradient_norm returns L2 norm of all gradients."""
+        from minivess.pipeline.training_diagnostics import compute_gradient_norm
+
+        model = nn.Linear(4, 2)
+        x = torch.randn(2, 4)
+        loss = model(x).sum()
+        loss.backward()
+
+        norm = compute_gradient_norm(model)
+        assert norm > 0.0
+        assert not torch.isnan(torch.tensor(norm))
+
+    def test_gradient_norm_zero_when_no_grad(self) -> None:
+        """Returns 0.0 when no parameters have gradients."""
+        from minivess.pipeline.training_diagnostics import compute_gradient_norm
+
+        model = nn.Linear(4, 2)
+        # No backward pass → no gradients
+        norm = compute_gradient_norm(model)
+        assert norm == 0.0
+
+
+class TestPredictionDiagnostics:
+    """Prediction diagnostics should compute stats and detect NaN."""
+
+    def test_compute_prediction_stats(self) -> None:
+        """compute_prediction_stats returns dict with min, max, mean, std."""
+        from minivess.pipeline.training_diagnostics import compute_prediction_stats
+
+        preds = torch.randn(2, 2, 8, 8)
+        stats = compute_prediction_stats(preds)
+        assert "pred_min" in stats
+        assert "pred_max" in stats
+        assert "pred_mean" in stats
+        assert "pred_std" in stats
+        assert stats["pred_std"] > 0.0
+
+    def test_detect_nan_predictions(self) -> None:
+        """has_nan_or_inf returns True for NaN predictions."""
+        from minivess.pipeline.training_diagnostics import has_nan_or_inf
+
+        preds = torch.tensor([1.0, float("nan"), 3.0])
+        assert has_nan_or_inf(preds) is True
+
+    def test_detect_inf_predictions(self) -> None:
+        """has_nan_or_inf returns True for Inf predictions."""
+        from minivess.pipeline.training_diagnostics import has_nan_or_inf
+
+        preds = torch.tensor([1.0, float("inf"), 3.0])
+        assert has_nan_or_inf(preds) is True
+
+    def test_normal_predictions(self) -> None:
+        """has_nan_or_inf returns False for normal predictions."""
+        from minivess.pipeline.training_diagnostics import has_nan_or_inf
+
+        preds = torch.randn(2, 2, 8, 8)
+        assert has_nan_or_inf(preds) is False


### PR DESCRIPTION
## Summary
- Fix SAM3 adapter bugs: LoRA dtype mismatch, MONAI dim ordering (B,C,H,W,D), FP16 feature cast, NaN guards
- Confirm H1: val_loss=NaN was sentinel from skipped validation, not computational NaN
- Document BF16 vs FP16 dtype fuckup — SAM3 HuggingFace uses bfloat16, code had float16 from Turing GPU era
- Add atomic checkpoints with SHA256 integrity + spot resume support
- Add multi-metric tracker for training diagnostics
- Part 5/6 of branch split from `feat/skypilot-runpod-gpu-offloading`

## Test plan
- [x] 27 files, pre-commit hooks pass
- [x] Adapter tests cover dim ordering, dtype, NaN guard, LoRA, checkpoint integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>