### PR TITLE
feat: compliance audit trail — ModelCard YAML, log_data_access, OpenLineage transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,11 @@ MONAI_LABEL_PORT=8000
 OLLAMA_PORT=11434
 MARQUEZ_PORT=5001
 MARQUEZ_API_PORT=5002
+# Marquez API URL for OpenLineage emission (Issue #799).
+# Set to enable HTTP transport to Marquez. Leave empty for local-only mode.
+# Docker Compose: http://minivess-marquez:5000 (container-internal)
+# Host-side: http://localhost:${MARQUEZ_API_PORT:-5002}
+MARQUEZ_URL=
 
 # =============================================================================
 #  CLOUD / REMOTE TRAINING (OPTIONAL)

--- a/src/minivess/compliance/model_card.py
+++ b/src/minivess/compliance/model_card.py
@@ -1,11 +1,28 @@
+"""Model Card generation for HuggingFace Model Hub and FDA traceability.
+
+Implements Mitchell et al. (2019) "Model Cards for Model Reporting" with
+HuggingFace-compatible YAML front matter generation.
+
+References:
+  - Issue #821: FDA audit trail + ModelCard
+  - Mitchell et al. (2019). "Model Cards for Model Reporting." FAT*
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
+
+import yaml
 
 
 @dataclass
 class ModelCard:
-    """Model Card for documentation and transparency (Mitchell et al., 2019)."""
+    """Model Card for documentation and transparency (Mitchell et al., 2019).
+
+    Generates HuggingFace-compatible YAML metadata and Markdown documentation
+    for model transparency and FDA IEC 62304 traceability.
+    """
 
     model_name: str
     model_version: str
@@ -21,8 +38,70 @@ class ModelCard:
     )
     caveats: str = ""
     authors: list[str] = field(default_factory=list)
+    license: str = "cc-by-nc-4.0"
+    pipeline_tag: str = "image-segmentation"
+    library_name: str = "monai"
+    tags: list[str] = field(
+        default_factory=lambda: ["medical-imaging", "segmentation", "3d"]
+    )
+
+    def to_yaml(self) -> str:
+        """Generate HuggingFace-compatible YAML metadata.
+
+        Returns valid YAML that can be used as front matter in a
+        HuggingFace Model Hub README.md file.
+
+        Returns
+        -------
+        str
+            YAML string with HuggingFace model card metadata.
+        """
+        metadata: dict[str, Any] = {
+            "model_name": self.model_name,
+            "model_type": self.model_type,
+            "pipeline_tag": self.pipeline_tag,
+            "library_name": self.library_name,
+            "license": self.license,
+            "tags": self.tags,
+        }
+
+        if self.metrics:
+            metadata["metrics"] = [
+                {"name": name, "type": name, "value": value}
+                for name, value in self.metrics.items()
+            ]
+
+        if self.authors:
+            metadata["authors"] = self.authors
+
+        result: str = yaml.dump(
+            metadata,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+        return result
+
+    def to_huggingface_readme(self) -> str:
+        """Generate a complete HuggingFace README with YAML front matter.
+
+        Returns
+        -------
+        str
+            Complete README.md content with YAML front matter and Markdown body.
+        """
+        yaml_section = self.to_yaml()
+        markdown_body = self.to_markdown()
+        return f"---\n{yaml_section}---\n{markdown_body}\n"
 
     def to_markdown(self) -> str:
+        """Generate Markdown documentation body.
+
+        Returns
+        -------
+        str
+            Markdown string with model card sections.
+        """
         sections = [
             f"# Model Card: {self.model_name} v{self.model_version}",
             f"\n## Model Details\n- **Type:** {self.model_type}"
@@ -42,3 +121,57 @@ class ModelCard:
         if self.authors:
             sections.append(f"\n## Authors\n{', '.join(self.authors)}")
         return "\n".join(sections)
+
+    @classmethod
+    def from_mlflow_run_dict(
+        cls,
+        run_dict: dict[str, Any],
+        *,
+        version: str = "0.1",
+    ) -> ModelCard:
+        """Construct a ModelCard from an MLflow run metadata dictionary.
+
+        Parameters
+        ----------
+        run_dict:
+            Dictionary with 'params', 'metrics', and optionally 'tags' keys.
+            Mirrors the structure of ``mlflow.get_run().data.to_dictionary()``.
+        version:
+            Model version string.
+
+        Returns
+        -------
+        ModelCard
+            Populated model card.
+        """
+        params = run_dict.get("params", {})
+        metrics_raw = run_dict.get("metrics", {})
+        tags = run_dict.get("tags", {})
+
+        model_family = params.get("model_family", "unknown")
+        loss_function = params.get("loss_function", "")
+        max_epochs = params.get("max_epochs", "")
+
+        # Filter to val/ metrics for the card
+        card_metrics: dict[str, float] = {}
+        for key, value in metrics_raw.items():
+            if key.startswith("val/"):
+                # Use the short name (e.g., "cldice" from "val/cldice")
+                short_name = key.split("/", 1)[1] if "/" in key else key
+                card_metrics[short_name] = float(value)
+
+        description_parts = [f"Model family: {model_family}"]
+        if loss_function:
+            description_parts.append(f"Loss: {loss_function}")
+        if max_epochs:
+            description_parts.append(f"Epochs: {max_epochs}")
+
+        run_name = tags.get("mlflow.runName", model_family)
+
+        return cls(
+            model_name=model_family,
+            model_version=version,
+            description=". ".join(description_parts),
+            metrics=card_metrics,
+            training_data=f"Run: {run_name}",
+        )

--- a/src/minivess/observability/lineage.py
+++ b/src/minivess/observability/lineage.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 from typing import TYPE_CHECKING
 
 from openlineage.client.event_v2 import (
@@ -68,6 +69,27 @@ class LineageEmitter:
                     "Could not connect to Marquez at %s; operating in local-only mode",
                     url,
                 )
+
+    @classmethod
+    def from_env(cls, namespace: str = "minivess") -> LineageEmitter:
+        """Construct a LineageEmitter from the MARQUEZ_URL environment variable.
+
+        Reads ``MARQUEZ_URL`` from the environment. If set and non-empty,
+        configures HttpTransport to send events to Marquez. Otherwise,
+        operates in local-only mode (events collected in memory).
+
+        Parameters
+        ----------
+        namespace:
+            OpenLineage namespace (default: ``"minivess"``).
+
+        Returns
+        -------
+        LineageEmitter
+            Configured emitter.
+        """
+        url = os.environ.get("MARQUEZ_URL") or None
+        return cls(namespace=namespace, url=url)
 
     def _now_iso(self) -> str:
         """Return current UTC time in ISO format."""

--- a/src/minivess/orchestration/flows/train_flow.py
+++ b/src/minivess/orchestration/flows/train_flow.py
@@ -24,6 +24,7 @@ import mlflow
 import yaml
 from prefect import flow, task
 
+from minivess.compliance.audit import AuditTrail
 from minivess.observability.infrastructure_timing import (
     estimate_cost_from_first_epoch,
     generate_timing_jsonl,
@@ -803,6 +804,39 @@ def training_flow(
     # Load fold splits (outside MLflow run — no side effects)
     splits = load_fold_splits_task(splits_dir)
     folds_to_run = splits[:num_folds]
+
+    # FDA audit trail: log data access (Issue #821 — IEC 62304 traceability)
+    dataset_name = (
+        config_dict.get("dataset_name", "minivess") if config_dict else "minivess"
+    )
+    file_paths: list[str] = []
+    for fold_split in folds_to_run:
+        # fold_split is FoldSplit dataclass (has .train/.val attrs) or dict
+        _train = (
+            fold_split.get("train", [])
+            if isinstance(fold_split, dict)
+            else getattr(fold_split, "train", [])
+        )
+        _val = (
+            fold_split.get("val", [])
+            if isinstance(fold_split, dict)
+            else getattr(fold_split, "val", [])
+        )
+        for entry in _train:
+            if isinstance(entry, dict) and "image" in entry:
+                file_paths.append(entry["image"])
+        for entry in _val:
+            if isinstance(entry, dict) and "image" in entry:
+                file_paths.append(entry["image"])
+    audit = AuditTrail()
+    audit.log_data_access(
+        dataset_name=dataset_name,
+        file_paths=file_paths,
+        actor="train-flow",
+    )
+    logger.info(
+        "Audit: logged data access for %s (%d files)", dataset_name, len(file_paths)
+    )
 
     # Build per-fold config dict
     config: dict[str, Any] = {

--- a/tests/v2/unit/test_agent_models.py
+++ b/tests/v2/unit/test_agent_models.py
@@ -8,6 +8,17 @@ pytest.importorskip("pydantic_ai", reason="pydantic_ai not installed")
 
 from pydantic import ValidationError  # noqa: E402
 
+try:
+    import pydantic_ai  # noqa: F401
+
+    _HAS_PYDANTIC_AI = True
+except ImportError:
+    _HAS_PYDANTIC_AI = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_PYDANTIC_AI, reason="pydantic_ai not installed"
+)
+
 
 class TestExperimentSummary:
     """T-1.1: ExperimentSummary output model."""

--- a/tests/v2/unit/test_api_consistency.py
+++ b/tests/v2/unit/test_api_consistency.py
@@ -8,6 +8,19 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
+
+try:
+    import pydantic_ai  # noqa: F401
+
+    _HAS_PYDANTIC_AI = True
+except ImportError:
+    _HAS_PYDANTIC_AI = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_PYDANTIC_AI, reason="pydantic_ai not installed"
+)
+
 # ---------------------------------------------------------------------------
 # T1: Factory functions use build_* naming
 # ---------------------------------------------------------------------------

--- a/tests/v2/unit/test_audit_trail_wiring.py
+++ b/tests/v2/unit/test_audit_trail_wiring.py
@@ -1,0 +1,83 @@
+"""Tests that verify AuditTrail.log_data_access() is wired into train_flow.
+
+PR-2 T2.1: The train flow MUST call log_data_access(dataset_name: str,
+file_paths: list[str]) after loading data — NOT split names. This test
+verifies the wiring via AST inspection of the source code.
+
+References:
+  - Issue #821: FDA-ready test set documentation and lineage tracking
+  - docs/planning/pre-full-gcp-housekeeping-and-qa.xml PR id="2" T2.1
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_FLOWS_DIR = Path("src/minivess/orchestration/flows")
+
+
+def _get_imported_names(filepath: Path) -> set[str]:
+    """Parse a Python file's AST and return all imported names."""
+    source = filepath.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(filepath))
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import | ast.ImportFrom):
+            for alias in node.names:
+                names.add(alias.asname if alias.asname else alias.name)
+    return names
+
+
+def _source_contains(filepath: Path, substring: str) -> bool:
+    """Check if a file's source code contains a substring."""
+    return substring in filepath.read_text(encoding="utf-8")
+
+
+class TestTrainFlowImportsAuditTrail:
+    """Train flow must import AuditTrail for data access logging."""
+
+    def test_train_flow_imports_audit_trail(self) -> None:
+        names = _get_imported_names(_FLOWS_DIR / "train_flow.py")
+        assert "AuditTrail" in names, (
+            "train_flow.py must import AuditTrail from compliance.audit"
+        )
+
+
+class TestTrainFlowCallsLogDataAccess:
+    """Train flow must call log_data_access() with correct signature."""
+
+    def test_train_flow_calls_log_data_access(self) -> None:
+        assert _source_contains(_FLOWS_DIR / "train_flow.py", "log_data_access"), (
+            "train_flow.py must call log_data_access()"
+        )
+
+    def test_train_flow_passes_dataset_name_to_log_data_access(self) -> None:
+        """log_data_access must receive dataset_name, not split names."""
+        assert _source_contains(_FLOWS_DIR / "train_flow.py", "dataset_name"), (
+            "train_flow.py must pass dataset_name to log_data_access()"
+        )
+
+    def test_train_flow_passes_file_paths_to_log_data_access(self) -> None:
+        """log_data_access must receive file_paths: list[str]."""
+        assert _source_contains(_FLOWS_DIR / "train_flow.py", "file_paths"), (
+            "train_flow.py must pass file_paths to log_data_access()"
+        )
+
+
+class TestAuditTrailLogDataAccessSignature:
+    """AuditTrail.log_data_access() must have the correct signature."""
+
+    def test_log_data_access_accepts_dataset_name_and_file_paths(self) -> None:
+        from minivess.compliance.audit import AuditTrail
+
+        trail = AuditTrail()
+        entry = trail.log_data_access(
+            dataset_name="minivess",
+            file_paths=["/data/raw/vol_001.nii.gz", "/data/raw/vol_002.nii.gz"],
+            actor="train-flow",
+        )
+        assert entry.event_type == "DATA_ACCESS"
+        assert entry.metadata["dataset"] == "minivess"
+        assert entry.metadata["num_files"] == 2
+        assert entry.data_hash is not None

--- a/tests/v2/unit/test_config_defaults.py
+++ b/tests/v2/unit/test_config_defaults.py
@@ -50,6 +50,12 @@ class TestBackwardsCompatibility:
         assert _DEFAULT_BATCH_SIZE == 2
 
     def test_default_model_importable_from_config(self) -> None:
+        import pytest
+
+        try:
+            import pydantic_ai  # noqa: F401
+        except ImportError:
+            pytest.skip("pydantic_ai not installed")
         from minivess.agents.config import AgentConfig
 
         assert AgentConfig().model == "anthropic:claude-sonnet-4-6"

--- a/tests/v2/unit/test_model_card.py
+++ b/tests/v2/unit/test_model_card.py
@@ -1,0 +1,149 @@
+"""Tests for ModelCard HuggingFace YAML generation.
+
+PR-2 T2.3: ModelCard must generate valid HuggingFace-format YAML front
+matter (metadata block) suitable for Model Hub upload.
+
+References:
+  - Issue #821: FDA audit trail + ModelCard
+  - docs/planning/pre-full-gcp-housekeeping-and-qa.xml PR id="2" T2.3
+  - Mitchell et al. (2019) "Model Cards for Model Reporting"
+"""
+
+from __future__ import annotations
+
+import yaml
+
+
+class TestModelCardToYaml:
+    """ModelCard must generate valid HuggingFace YAML front matter."""
+
+    def test_model_card_has_to_yaml_method(self) -> None:
+        from minivess.compliance.model_card import ModelCard
+
+        card = ModelCard(model_name="DynUNet", model_version="1.0")
+        assert hasattr(card, "to_yaml"), "ModelCard must have to_yaml() method"
+
+    def test_model_card_yaml_is_valid(self) -> None:
+        from minivess.compliance.model_card import ModelCard
+
+        card = ModelCard(
+            model_name="DynUNet",
+            model_version="1.0",
+            model_type="3D Segmentation",
+            description="Vessel segmentation model",
+            training_data="MiniVess (70 volumes)",
+            evaluation_data="MiniVess 3-fold CV",
+            metrics={"cldice": 0.812, "masd": 3.45},
+            authors=["Teikari et al."],
+        )
+        yaml_str = card.to_yaml()
+        # Must be parseable YAML
+        parsed = yaml.safe_load(yaml_str)
+        assert isinstance(parsed, dict)
+
+    def test_model_card_yaml_has_required_hf_fields(self) -> None:
+        """HuggingFace model card YAML requires certain top-level keys."""
+        from minivess.compliance.model_card import ModelCard
+
+        card = ModelCard(
+            model_name="DynUNet",
+            model_version="1.0",
+            model_type="3D Segmentation",
+            description="Vessel segmentation model",
+            training_data="MiniVess (70 volumes)",
+            evaluation_data="MiniVess 3-fold CV",
+            metrics={"cldice": 0.812, "masd": 3.45},
+            authors=["Teikari et al."],
+        )
+        yaml_str = card.to_yaml()
+        parsed = yaml.safe_load(yaml_str)
+
+        # HuggingFace model card YAML metadata fields
+        assert "model_name" in parsed or "model-name" in parsed
+        assert "model_type" in parsed or "pipeline_tag" in parsed
+        assert "metrics" in parsed
+        assert "license" in parsed
+
+    def test_model_card_yaml_metrics_are_list_of_dicts(self) -> None:
+        """HuggingFace format uses list of dicts for metrics."""
+        from minivess.compliance.model_card import ModelCard
+
+        card = ModelCard(
+            model_name="DynUNet",
+            model_version="1.0",
+            metrics={"cldice": 0.812, "masd": 3.45},
+        )
+        yaml_str = card.to_yaml()
+        parsed = yaml.safe_load(yaml_str)
+
+        metrics = parsed["metrics"]
+        assert isinstance(metrics, list)
+        assert all(isinstance(m, dict) for m in metrics)
+        # Each metric dict should have "name" and "value"
+        metric_names = {m["name"] for m in metrics}
+        assert "cldice" in metric_names
+        assert "masd" in metric_names
+
+    def test_model_card_yaml_license_field(self) -> None:
+        from minivess.compliance.model_card import ModelCard
+
+        card = ModelCard(model_name="DynUNet", model_version="1.0")
+        yaml_str = card.to_yaml()
+        parsed = yaml.safe_load(yaml_str)
+        # License must be present and non-empty
+        assert "license" in parsed
+        assert parsed["license"]
+
+    def test_model_card_to_huggingface_readme(self) -> None:
+        """Full HuggingFace README with YAML front matter + Markdown body."""
+        from minivess.compliance.model_card import ModelCard
+
+        card = ModelCard(
+            model_name="DynUNet",
+            model_version="1.0",
+            model_type="3D Segmentation",
+            description="Vessel segmentation model",
+            metrics={"cldice": 0.812},
+        )
+        readme = card.to_huggingface_readme()
+        # Must start with YAML front matter
+        assert readme.startswith("---\n")
+        # Must have closing YAML delimiter
+        parts = readme.split("---\n")
+        # parts[0] is empty (before first ---), parts[1] is YAML, rest is Markdown
+        assert len(parts) >= 3
+        # YAML section must be valid
+        yaml_section = parts[1]
+        parsed = yaml.safe_load(yaml_section)
+        assert isinstance(parsed, dict)
+        # Markdown body must follow
+        markdown_body = "---\n".join(parts[2:])
+        assert "Model Card" in markdown_body or "DynUNet" in markdown_body
+
+
+class TestModelCardFromMlflowRun:
+    """ModelCard can be populated from MLflow run metadata."""
+
+    def test_from_mlflow_dict(self) -> None:
+        """ModelCard.from_mlflow_run_dict() constructs card from run dict."""
+        from minivess.compliance.model_card import ModelCard
+
+        run_dict = {
+            "params": {
+                "model_family": "dynunet",
+                "loss_function": "cbdice_cldice",
+                "max_epochs": "50",
+            },
+            "metrics": {
+                "val/cldice": 0.812,
+                "val/masd": 3.45,
+                "val/dice": 0.891,
+            },
+            "tags": {
+                "mlflow.runName": "dynunet_cbdice_fold0",
+            },
+        }
+        card = ModelCard.from_mlflow_run_dict(run_dict, version="1.0")
+        assert card.model_name == "dynunet"
+        assert card.model_version == "1.0"
+        assert "cldice" in card.metrics or "val/cldice" in card.metrics

--- a/tests/v2/unit/test_openlineage_emission.py
+++ b/tests/v2/unit/test_openlineage_emission.py
@@ -1,0 +1,193 @@
+"""Tests for OpenLineage v2 emission with HTTP transport.
+
+PR-2 T2.5: LineageEmitter must send valid OpenLineage v2 events when
+configured with a Marquez URL (via HttpTransport). Mock-tested only --
+full Marquez deployment deferred to separate issue.
+
+References:
+  - Issue #799: OpenLineage/Marquez integration
+  - docs/planning/pre-full-gcp-housekeeping-and-qa.xml PR id="2" T2.5
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+
+class TestLineageEmitterHttpTransport:
+    """LineageEmitter configures HttpTransport when MARQUEZ_URL is provided."""
+
+    def test_emitter_creates_client_with_url(self) -> None:
+        """When url is provided, LineageEmitter attempts to create an OpenLineageClient.
+
+        Since no actual Marquez server is running, the constructor catches
+        the connection error and falls back to local-only. We test that
+        providing a URL does NOT raise.
+        """
+        from minivess.observability.lineage import LineageEmitter
+
+        # Constructor should not raise even with unreachable URL
+        emitter = LineageEmitter(url="http://localhost:59999")
+        # Client may or may not be set depending on whether the transport
+        # can be constructed. The key guarantee: no exception raised.
+        assert emitter.url == "http://localhost:59999"
+
+    def test_emitter_no_client_without_url(self) -> None:
+        """Without url, LineageEmitter operates in local-only mode."""
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        assert emitter._client is None
+
+    def test_emitter_emits_to_client(self) -> None:
+        """When client exists, emit() calls client.emit()."""
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        emitter._client = MagicMock()
+
+        emitter.emit_start("test-job")
+        emitter._client.emit.assert_called_once()
+
+    def test_emitter_graceful_on_client_failure(self) -> None:
+        """If client.emit() raises, event is still stored locally."""
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        emitter._client = MagicMock()
+        emitter._client.emit.side_effect = ConnectionError("mock error")
+
+        # Should not raise
+        event = emitter.emit_start("test-job")
+        assert event is not None
+        assert len(emitter.events) == 1
+
+
+class TestLineageEmitterFromEnv:
+    """LineageEmitter.from_env() reads MARQUEZ_URL from environment."""
+
+    def test_from_env_reads_marquez_url(self) -> None:
+        """from_env() constructs emitter with MARQUEZ_URL."""
+        from minivess.observability.lineage import LineageEmitter
+
+        old_val = os.environ.get("MARQUEZ_URL")
+        os.environ["MARQUEZ_URL"] = "http://localhost:5002"
+        try:
+            emitter = LineageEmitter.from_env()
+            assert emitter.url == "http://localhost:5002"
+        finally:
+            if old_val is not None:
+                os.environ["MARQUEZ_URL"] = old_val
+            else:
+                os.environ.pop("MARQUEZ_URL", None)
+
+    def test_from_env_local_mode_without_env_var(self) -> None:
+        """from_env() operates in local-only mode when MARQUEZ_URL is unset."""
+        from minivess.observability.lineage import LineageEmitter
+
+        old_val = os.environ.pop("MARQUEZ_URL", None)
+        try:
+            emitter = LineageEmitter.from_env()
+            assert emitter.url is None
+            assert emitter._client is None
+        finally:
+            if old_val is not None:
+                os.environ["MARQUEZ_URL"] = old_val
+
+    def test_from_env_empty_string_is_local_mode(self) -> None:
+        """from_env() treats empty MARQUEZ_URL as local-only mode."""
+        from minivess.observability.lineage import LineageEmitter
+
+        old_val = os.environ.get("MARQUEZ_URL")
+        os.environ["MARQUEZ_URL"] = ""
+        try:
+            emitter = LineageEmitter.from_env()
+            assert emitter.url is None
+            assert emitter._client is None
+        finally:
+            if old_val is not None:
+                os.environ["MARQUEZ_URL"] = old_val
+            else:
+                os.environ.pop("MARQUEZ_URL", None)
+
+
+class TestOpenLineageV2EventSchema:
+    """Emitted events must conform to OpenLineage v2 schema."""
+
+    def test_start_event_has_required_fields(self) -> None:
+        from openlineage.client.event_v2 import RunState
+
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        event = emitter.emit_start(
+            "test-job",
+            inputs=[{"namespace": "minivess", "name": "raw_data"}],
+            outputs=[{"namespace": "minivess", "name": "checkpoints"}],
+        )
+
+        assert event.eventType == RunState.START
+        assert event.run is not None
+        assert event.run.runId is not None
+        assert event.job is not None
+        assert event.job.name == "test-job"
+        assert event.job.namespace == "minivess"
+        assert event.eventTime is not None
+        assert event.producer == "minivess-mlops"
+
+    def test_complete_event_has_required_fields(self) -> None:
+        from openlineage.client.event_v2 import RunState
+
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        start = emitter.emit_start("test-job")
+        event = emitter.emit_complete("test-job", run_id=start.run.runId)
+
+        assert event.eventType == RunState.COMPLETE
+        assert event.run.runId == start.run.runId
+
+    def test_fail_event_has_required_fields(self) -> None:
+        from openlineage.client.event_v2 import RunState
+
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        start = emitter.emit_start("test-job")
+        event = emitter.emit_fail("test-job", run_id=start.run.runId)
+
+        assert event.eventType == RunState.FAIL
+        assert event.run.runId == start.run.runId
+
+    def test_pipeline_run_context_manager_emits_start_and_complete(self) -> None:
+        from openlineage.client.event_v2 import RunState
+
+        from minivess.observability.lineage import LineageEmitter
+
+        emitter = LineageEmitter()
+        with emitter.pipeline_run(
+            "test-flow",
+            inputs=[{"namespace": "minivess", "name": "input_data"}],
+            outputs=[{"namespace": "minivess", "name": "output_data"}],
+        ) as run_id:
+            assert run_id is not None
+
+        events = emitter.get_events_for_job("test-flow")
+        assert len(events) == 2
+        assert events[0].eventType == RunState.START
+        assert events[1].eventType == RunState.COMPLETE
+
+
+class TestMarquezUrlInEnvExample:
+    """MARQUEZ_URL must be in .env.example (Rule #22: single-source config)."""
+
+    def test_marquez_url_in_env_example(self) -> None:
+        from pathlib import Path
+
+        env_example = Path(".env.example")
+        assert env_example.exists(), ".env.example must exist"
+        content = env_example.read_text(encoding="utf-8")
+        assert "MARQUEZ_URL=" in content, (
+            "MARQUEZ_URL must be defined in .env.example (Rule #22)"
+        )


### PR DESCRIPTION
## Summary
- **T2.1/T2.2**: Wire `AuditTrail.log_data_access(dataset_name, file_paths)` into `train_flow.py` — logs actual image file paths from fold splits (not split names). Handles both `FoldSplit` dataclass and dict access patterns.
- **T2.3/T2.4**: Extend `ModelCard` with `to_yaml()` (HuggingFace-compatible YAML metadata), `to_huggingface_readme()` (YAML front matter + Markdown body), and `from_mlflow_run_dict()` (populate from MLflow run data). License defaults to `cc-by-nc-4.0`.
- **T2.5/T2.6**: Add `LineageEmitter.from_env()` classmethod reading `MARQUEZ_URL` from environment. Add `MARQUEZ_URL=` to `.env.example` (Rule #22). HTTP transport is mock-tested; full Marquez deployment deferred.
- **T2.7**: `make test-staging` passes with **5070 passed, 125 skipped, 0 failed**.
- **Bonus**: Fix 69 pre-existing test failures from missing optional deps (pydantic_ai, evidently Python 3.13 SyntaxError, whylogs, pandera, cyclonedx-bom) by adding proper `pytest.mark.skipif` markers.

Closes #799, closes #821.

## Test plan
- [x] `tests/v2/unit/test_audit_trail_wiring.py` — 5 tests verifying AST-level wiring + signature
- [x] `tests/v2/unit/test_model_card.py` — 7 tests for YAML generation, HF README, from_mlflow_run_dict
- [x] `tests/v2/unit/test_openlineage_emission.py` — 12 tests for HTTP transport, from_env, v2 schema, MARQUEZ_URL in .env.example
- [x] `make test-staging` — zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)