### PR TITLE
feat: create factorial-monitor skill for multi-job SkyPilot experiments

### DIFF
--- a/.claude/skills/factorial-monitor/SKILL.md
+++ b/.claude/skills/factorial-monitor/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: factorial-monitor
+version: 1.0.0
+description: >
+  Multi-job factorial experiment monitoring, aggregated diagnosis, and selective
+  re-launch for SkyPilot jobs. Use when running factorial experiments (model x loss
+  x calibration x fold) via SkyPilot and you need to track all jobs, aggregate
+  failures by root cause, and re-launch only failed conditions.
+  Do NOT use for: single-job monitoring (use ralph-loop), local test failures
+  (use self-learning-iterative-coder), or sequential plan execution (use overnight-runner).
+last_updated: 2026-03-19
+activation: manual
+invocation: /factorial-monitor
+metadata:
+  category: operations
+  tags: [skypilot, monitoring, factorial, cloud, batch, gcp, experiment]
+  relations:
+    compose_with:
+      - ralph-loop
+      - self-learning-iterative-coder
+      - issue-creator
+    depend_on:
+      - ralph-loop
+    similar_to: []
+    belong_to:
+      - overnight-runner
+---
+
+# Factorial Monitor
+
+> Multi-job factorial experiment monitoring with aggregated diagnosis, batch error
+> resolution, and selective re-launch. The outer loop that orchestrates ralph-loop
+> (per-job diagnosis) and self-learning-iterative-coder (batch code fixes).
+
+## Non-Negotiable Rules
+
+Five rules prevent ALL known anti-patterns. Read [instructions/rules.md](instructions/rules.md)
+for full details with rationale. Summary:
+
+| Rule | Name | Prevents |
+|------|------|----------|
+| F1 | WAIT-FOR-TERMINAL | Panic fixing, premature whac-a-mole |
+| F2 | AGGREGATE-BEFORE-FIX | Silent dismissal, serial fixing |
+| F3 | REBUILD-BEFORE-RELAUNCH | Docker image staleness |
+| F4 | MAX-TWO-CYCLES | Infinite fix-relaunch loops, cost overrun |
+| F5 | FACTORIAL-MANIFEST | Partial factorial amnesia |
+
+**Kill-switch exception** (Rule F1): If 3+ jobs fail with IDENTICAL error within 5 min
+AND remaining running jobs haven't passed the failure point → cancel same-config jobs,
+begin batch diagnosis. Different-config jobs continue.
+
+## Workflow (6 Phases)
+
+```
+Phase 1: LAUNCH       → protocols/launch.md
+Phase 2: MONITOR      → protocols/monitor.md       (polling loop, READ-ONLY)
+Phase 3: DIAGNOSE     → protocols/diagnose.md       (batch aggregation)
+Phase 4: FIX          → protocols/fix.md            (reviewer-backed batch fix)
+Phase 5: RELAUNCH     → protocols/relaunch.md       (selective, max 2 cycles)
+Phase 6: REPORT       → protocols/report.md         (final summary + issues)
+```
+
+### Phase 1: LAUNCH
+- Execute `run_factorial.sh <config.yaml>` or confirm already launched
+- Create `factorial_manifest.json` mapping job_id → condition
+- Verify SkyPilot YAML uses `image_id: docker:...` (Rule #17 — no bare VM)
+- Record experiment_id, factors, levels, expected job count
+- See: [protocols/launch.md](protocols/launch.md)
+
+### Phase 2: MONITOR (polling loop)
+- Poll `sky jobs queue` every 60s
+- Print live status table: `| condition | job_id | status | duration |`
+- For each newly-terminal failure: call `ralph_monitor.analyze_logs()`
+- **READ-ONLY**: no code changes, no SSH, no `sky exec` while jobs run
+- Continue until ALL jobs reach terminal state (Rule F1)
+- See: [protocols/monitor.md](protocols/monitor.md)
+
+### Phase 3: DIAGNOSE (all jobs terminal)
+- Group failures by root cause category using ralph_monitor categories
+- Present ONE aggregated report (Rule F2)
+- Format: `{root_cause → [job_ids], fix_strategy, affected_files, confidence}`
+- If 0 failures → skip to REPORT
+- See: [protocols/diagnose.md](protocols/diagnose.md)
+
+### Phase 4: FIX (with reviewer agents)
+- For EACH root cause: plan batch fix strategy with reviewer agents
+- If code fix needed → compose_with: self-learning-iterative-coder
+- If config fix → edit YAML/env directly
+- Execute Rule F3: `make test-staging` → Docker rebuild → push → verify digest
+- Commit all fixes in ONE batch commit
+- See: [protocols/fix.md](protocols/fix.md)
+
+### Phase 5: RELAUNCH (max 2 cycles)
+- Generate filtered re-launch command (ONLY failed conditions)
+- Execute and return to MONITOR phase
+- Update manifest with `relaunch_batch` number
+- Rule F4: hard stop after 2 cycles → escalate to user
+- See: [protocols/relaunch.md](protocols/relaunch.md)
+
+### Phase 6: REPORT
+- Summary: X succeeded, Y failed (root causes: A, B, C)
+- Cost: total $ across all cycles
+- If unrecoverable failures → compose_with: issue-creator
+- Save to `outputs/factorial_run_<experiment_id>.jsonl`
+- See: [protocols/report.md](protocols/report.md)
+
+## Integration Points
+
+| Skill | How It Integrates |
+|-------|-------------------|
+| `ralph-loop` | Per-job diagnosis via `analyze_logs()` — reuses failure pattern library |
+| `self-learning-iterative-coder` | TDD loop when fixes require code changes |
+| `issue-creator` | Unrecoverable failures after 2 cycles become GitHub issues |
+| `overnight-runner` | Factorial runs are a type of batch execution |
+
+## Quality Evaluation
+
+See [eval/checklist.md](eval/checklist.md) for 5 binary pass/fail criteria.
+
+## Manifest Schema
+
+See [templates/factorial-manifest.json](templates/factorial-manifest.json) for the
+experiment state tracking schema.

--- a/.claude/skills/factorial-monitor/eval/checklist.md
+++ b/.claude/skills/factorial-monitor/eval/checklist.md
@@ -1,0 +1,44 @@
+# Eval Checklist — Factorial Monitor
+
+Binary pass/fail criteria. Maximum 5 per autoresearch guidelines.
+
+## Structural Criteria
+
+1. **All-jobs-tracked**
+   - Every condition in the factorial grid has a corresponding job_id in the manifest.
+   - Pass: Manifest job count equals expected condition count from config YAML.
+   - Fail: Any condition missing or untracked.
+
+2. **Selective-relaunch**
+   - Re-launch command launches ONLY failed conditions, not the entire grid.
+   - Pass: Re-launched job count < total job count.
+   - Fail: Full grid re-launched (wasting cloud spend on already-succeeded jobs).
+
+3. **Cost-logged**
+   - Total estimated cost recorded in manifest and final report.
+   - Pass: Cost field present and non-zero for completed jobs.
+   - Fail: Cost missing or zero.
+
+## Behavioral Criteria
+
+4. **Failures-aggregated-not-serial**
+   - When multiple jobs failed, ONE aggregated diagnosis grouped by root cause was presented.
+   - Pass: Single batch report with categories + counts before any fix attempt.
+   - Fail: Separate per-job reports, or fixing started before all failures collected.
+
+5. **No-silent-dismiss**
+   - Every failed job resulted in: (a) fixed + relaunched, (b) GitHub issue created, or (c) explicitly reported to user.
+   - Pass: Zero failures left unaccounted in the manifest.
+   - Fail: Any failure classified as "pre-existing" or "transient" without evidence.
+
+## Trigger Tests
+
+**Should trigger:**
+- "Monitor the factorial debug run"
+- "Track all the SkyPilot jobs from the experiment"
+- "Launch and monitor the factorial experiment"
+
+**Should NOT trigger:**
+- "Monitor this single SkyPilot job" (use ralph-loop)
+- "Fix these test failures" (use self-learning-iterative-coder)
+- "Create a GitHub issue" (use issue-creator)

--- a/.claude/skills/factorial-monitor/instructions/rules.md
+++ b/.claude/skills/factorial-monitor/instructions/rules.md
@@ -1,0 +1,129 @@
+# Non-Negotiable Rules — Factorial Monitor
+
+Five rules that prevent every known anti-pattern from the metalearning history.
+These are CROSS-CUTTING — they apply to ALL phases.
+
+## Rule F1: WAIT-FOR-TERMINAL
+
+> No error diagnosis, no code fixes, no re-launches until ALL factorial jobs
+> have reached terminal state (SUCCEEDED / FAILED / FAILED_SETUP / CANCELLED).
+
+**Permitted during execution:**
+- `sky jobs queue` (status polling)
+- `sky jobs logs <id>` (read-only log inspection)
+- Reading MLflow metrics
+- `sky jobs cancel <id>` for a job PROVABLY wasting money (infinite loop, disk full)
+
+**BANNED during execution:**
+- `sky exec` (SSH into running pods)
+- Code changes to `src/` or `configs/`
+- Docker image rebuilds
+- "This job looks like it will fail" as grounds for cancellation
+
+**Kill-switch exception:** If 3+ jobs fail with the IDENTICAL error (same traceback,
+same root cause category) within 5 minutes AND remaining running jobs haven't passed
+the failure point → cancel remaining same-config jobs, begin batch diagnosis. Jobs
+with DIFFERENT configurations continue running.
+
+**Why:** Premature diagnosis on partial information causes Panic Fixing (Anti-Pattern 3)
+and Whac-a-Mole (Anti-Pattern 2). Let jobs run to completion to get the full picture.
+
+**Source:** `.claude/metalearning/2026-03-18-whac-a-mole-serial-failure-fixing.md`
+
+---
+
+## Rule F2: AGGREGATE-BEFORE-FIX
+
+> After all jobs reach terminal state, collect ALL failure logs and categorize
+> by root cause BEFORE writing any fix.
+
+**Required output format:**
+```json
+{
+  "root_cause_id": "DVC_NO_GIT",
+  "description": ".dvc not initialized in container",
+  "affected_jobs": [3, 7, 11],
+  "fix_strategy": "Add dvc init to Docker entrypoint",
+  "affected_files": ["deployment/Dockerfile.train"],
+  "confidence": "high"
+}
+```
+
+**BANNED:**
+- Fixing the first failure you see
+- Re-launching a failed job without a written root cause
+- "Probably transient" without evidence (spot preemption exit code 24, or identical
+  job succeeded on zero-code-change retry)
+- "Pre-existing" as a failure classification
+- "Not related to current changes" as an excuse to skip
+
+**Why:** Silent dismissal (Anti-Pattern 1) and serial fixing (Anti-Pattern 2) are the
+two most expensive failure modes. One root cause often explains 5+ job failures.
+Batch fixing saves GPU-hours.
+
+**Source:** `.claude/metalearning/2026-03-07-silent-existing-failures.md`
+
+---
+
+## Rule F3: REBUILD-BEFORE-RELAUNCH
+
+> Every fix-relaunch cycle MUST execute this exact sequence:
+> 1. Code fix with tests
+> 2. `make test-staging` passes
+> 3. Docker image rebuild + push with new tag
+> 4. Update SkyPilot YAML to reference new image tag/digest
+> 5. Re-launch ONLY the failed jobs
+
+**Skipping ANY step is BANNED.**
+
+Re-launching with a stale Docker image is the most expensive possible mistake —
+it wastes the full GPU cost of every re-launched job while producing identical failures.
+
+**Verification command:** Before re-launching, run:
+```bash
+docker manifest inspect <image:tag> | python3 -c "import sys,json; print(json.load(sys.stdin)['config']['digest'][:16])"
+```
+Compare with the digest in the SkyPilot YAML.
+
+**Why:** Docker Image Staleness (Anti-Pattern 9) was identified by the anti-pattern
+reviewer as having CRITICAL severity. Every re-launch without rebuild = wasted money.
+
+---
+
+## Rule F4: MAX-TWO-CYCLES
+
+> A factorial run permits at most 2 fix-relaunch cycles (initial launch + 2 retries).
+> If jobs still fail after the second cycle, STOP.
+
+**On hitting the limit, produce a diagnostic report:**
+- All root causes found across all cycles
+- All fixes attempted and their outcomes
+- Cost incurred so far (jobs x duration x hourly rate)
+- Recommendation: redesign experiment, fix upstream dependency, or authorize
+  additional cycles with explicit budget cap
+
+**Why:** Without a hard stop, fix-relaunch loops can run indefinitely. Each cycle
+costs real money. The user decides whether to spend more, not Claude.
+
+---
+
+## Rule F5: FACTORIAL-MANIFEST
+
+> Before launch, create `factorial_manifest.json` that is the SINGLE SOURCE OF TRUTH
+> for experiment state.
+
+**Required fields:**
+- `experiment_id`: Unique identifier (timestamp + config name)
+- `config_file`: Path to the factorial YAML
+- `factors`: Dict of factor names → levels
+- `jobs`: List of `{condition, job_id, status, start_time, end_time, cost,
+  mlflow_run_id, failure_category, relaunch_batch}`
+
+**Invariants:**
+- Re-launched jobs update the EXISTING entry (same condition), not create new entries
+- `relaunch_batch` tracks which cycle: 0=original, 1=first retry, 2=second retry
+- No job result is valid unless it appears in the manifest
+- Manifest is saved to `outputs/factorial_manifest_<experiment_id>.json`
+
+**Why:** Without a manifest, partial factorial completion leads to amnesia —
+forgetting which conditions succeeded in batch 1 when fixing batch 2 failures.

--- a/.claude/skills/factorial-monitor/protocols/diagnose.md
+++ b/.claude/skills/factorial-monitor/protocols/diagnose.md
@@ -1,0 +1,61 @@
+# Protocol: Diagnose
+
+## Prerequisites
+
+- ALL factorial jobs are in terminal state (Rule F1)
+- Each failed job has a preliminary FailureInfo from ralph_monitor.analyze_logs()
+
+## Aggregation (Rule F2)
+
+Group ALL failures by root cause category:
+
+```
+Root Cause Report
+─────────────────
+Category: DVC_NO_GIT (4 jobs)
+  Jobs: [103, 107, 111, 115]
+  Conditions: sam3/cbdice/fold-0, sam3/cbdice/fold-1, sam3/cldice/fold-0, sam3/cldice/fold-1
+  Root cause: .dvc not initialized in container
+  Fix strategy: Add dvc init to Docker entrypoint
+  Auto-fixable: YES
+  Confidence: HIGH
+
+Category: OOM (2 jobs)
+  Jobs: [109, 113]
+  Conditions: sam3/cbdice/fold-2, sam3/cldice/fold-2
+  Root cause: GPU VRAM exhausted at fold-2 (more data)
+  Fix strategy: Reduce batch_size or patch_size for SAM3
+  Auto-fixable: NO (requires config decision)
+  Confidence: MEDIUM
+
+Summary: 18/24 SUCCEEDED, 6 FAILED
+  Root causes: DVC_NO_GIT (4), OOM (2)
+```
+
+## Pattern Detection
+
+Look for patterns across failures:
+- **Model-specific**: "All SAM3 jobs failed" → model configuration issue
+- **Fold-specific**: "All fold-2 failed" → data size issue
+- **Loss-specific**: "All cbdice failed" → loss function bug
+- **Universal**: "All jobs failed" → infrastructure issue (Docker, DVC, env vars)
+
+## Categorization Rules
+
+For each root cause, classify:
+- **AUTO-FIXABLE**: Infrastructure issues with clear fixes (DVC_NO_GIT, DISK_FULL, ENV_VAR_LITERAL)
+- **CONFIG-FIXABLE**: Requires parameter changes (OOM → reduce batch_size)
+- **CODE-FIXABLE**: Requires code changes (bug in loss function, import error)
+- **UNRECOVERABLE**: Cannot be fixed without user decision (DATA_MISSING, REGISTRY_AUTH)
+
+## "Transient" Classification
+
+"Probably transient" is BANNED unless:
+- The failure is a confirmed spot preemption (SkyPilot exit code 24)
+- An identical job with identical code succeeded in a different region
+- The error is a known cloud provider intermittent (specific API timeout patterns)
+
+## Transition to FIX
+
+If any failures exist, present the aggregated report and transition to FIX.
+If 0 failures, skip directly to REPORT.

--- a/.claude/skills/factorial-monitor/protocols/fix.md
+++ b/.claude/skills/factorial-monitor/protocols/fix.md
@@ -1,0 +1,66 @@
+# Protocol: Fix
+
+## Prerequisites
+
+- Aggregated diagnosis report from DIAGNOSE phase
+- All failures grouped by root cause
+
+## Fix Strategy Selection
+
+For EACH root cause category, determine the fix approach:
+
+| Category | Approach |
+|----------|----------|
+| AUTO-FIXABLE (DVC_NO_GIT, DISK_FULL, ENV_VAR_LITERAL) | Direct fix → test → rebuild |
+| CONFIG-FIXABLE (OOM, TIMEOUT) | Edit config YAML → test → rebuild |
+| CODE-FIXABLE (import error, loss function bug) | compose_with: self-learning-iterative-coder |
+| UNRECOVERABLE (DATA_MISSING, REGISTRY_AUTH) | compose_with: issue-creator → report to user |
+
+## Batch Fix Execution
+
+Fix ALL root causes in a single pass. Do NOT fix one, re-launch, then fix the next.
+
+1. **Plan with reviewer agents**: For each root cause, draft the fix strategy.
+   Use parallel reviewer agents to evaluate the plan:
+   - Does this fix address ALL affected jobs?
+   - Could this fix break any currently-SUCCEEDED jobs?
+   - Is the fix reproducible in Docker?
+
+2. **Implement fixes**: Apply all fixes. For code changes, use the TDD skill's
+   failure triage protocol (GATHER → CATEGORIZE → PLAN → FIX → VERIFY).
+
+3. **Local verification**: `make test-staging` must pass.
+
+4. **Docker rebuild** (Rule F3 — MANDATORY):
+   ```bash
+   # Build
+   docker build -t <image:tag> -f deployment/docker/Dockerfile.train .
+   # Push
+   docker push <image:tag>
+   # Verify digest
+   docker manifest inspect <image:tag> | head -5
+   ```
+
+5. **Update SkyPilot YAML**: Ensure `image_id:` references the new image tag.
+
+6. **Commit**: ONE batch commit for all fixes.
+   ```
+   fix: factorial run <experiment_id> — <N> root causes fixed
+
+   Root causes:
+   - DVC_NO_GIT: Added dvc init to entrypoint (4 jobs)
+   - OOM: Reduced SAM3 patch_size to 96 (2 jobs)
+   ```
+
+## Code Freeze Verification
+
+Before transitioning to RELAUNCH, verify:
+- [ ] `make test-staging` passes
+- [ ] Docker image rebuilt and pushed
+- [ ] SkyPilot YAML references new image
+- [ ] All fixes committed
+- [ ] No uncommitted changes in `src/` or `configs/`
+
+## Transition to RELAUNCH
+
+Once all fixes are verified, transition to RELAUNCH.

--- a/.claude/skills/factorial-monitor/protocols/launch.md
+++ b/.claude/skills/factorial-monitor/protocols/launch.md
@@ -1,0 +1,56 @@
+# Protocol: Launch
+
+## Pre-Launch Verification
+
+Before launching ANY factorial experiment:
+
+1. **Verify Docker image exists and is fresh:**
+   ```bash
+   docker manifest inspect <image:tag>
+   ```
+
+2. **Verify SkyPilot YAML uses Docker (Rule #17):**
+   ```bash
+   grep "image_id:" deployment/skypilot/train_factorial.yaml
+   ```
+   Must contain `docker:` prefix. Bare VM setup is BANNED.
+
+3. **Verify .env populated:**
+   Required: `HF_TOKEN`, `MLFLOW_TRACKING_URI`, GCP credentials.
+
+4. **Verify DVC data accessible:**
+   ```bash
+   dvc status -r gcs
+   ```
+
+5. **Estimate cost:**
+   ```
+   N_jobs x estimated_hours x hourly_rate = total_estimate
+   ```
+   Report to user before launching. Get explicit approval if >$20.
+
+## Launch Execution
+
+```bash
+./scripts/run_factorial.sh <config.yaml>
+```
+
+The script loops through all factorial conditions and calls `sky jobs launch` for each.
+
+## Manifest Creation
+
+After launch, parse SkyPilot output to build `factorial_manifest.json`:
+
+```bash
+sky jobs queue
+```
+
+Map each job_id to its condition (model, loss, aux_calib, fold) using the launch
+order from the config YAML.
+
+Save manifest to: `outputs/factorial_manifest_<experiment_id>.json`
+
+## Transition to MONITOR
+
+Once all jobs are launched and the manifest is populated, enter the MONITOR phase.
+From this point, the workspace is READ-ONLY (Rule F1).

--- a/.claude/skills/factorial-monitor/protocols/monitor.md
+++ b/.claude/skills/factorial-monitor/protocols/monitor.md
@@ -1,0 +1,64 @@
+# Protocol: Monitor
+
+## Polling Loop
+
+Poll `sky jobs queue` every 60 seconds. For each poll:
+
+1. Parse ALL job statuses from queue output
+2. Update the manifest with current status for each job
+3. Print a live status table:
+
+```
+┌───────────────────────────────────────────────────────────┐
+│ Factorial Monitor — experiment_2026-03-19_debug           │
+│ Poll #42 — 14:32:15 UTC                                  │
+├─────────────┬──────────┬──────┬───────────┬───────────────┤
+│ Condition   │ Job ID   │ Fold │ Status    │ Duration      │
+├─────────────┼──────────┼──────┼───────────┼───────────────┤
+│ dynunet/dice│ 101      │ 0    │ SUCCEEDED │ 0:45:12       │
+│ dynunet/dice│ 102      │ 1    │ RUNNING   │ 0:32:05       │
+│ sam3/cbdice │ 103      │ 0    │ FAILED    │ 0:12:33       │
+│ ...         │ ...      │ ...  │ ...       │ ...           │
+├─────────────┴──────────┴──────┴───────────┴───────────────┤
+│ Progress: 8/24 SUCCEEDED │ 1 FAILED │ 15 RUNNING         │
+│ Est. cost so far: $4.20                                   │
+└───────────────────────────────────────────────────────────┘
+```
+
+## READ-ONLY Constraint (Rule F1)
+
+During monitoring, the ONLY permitted actions are:
+- `sky jobs queue` — status polling
+- `sky jobs logs <id>` — read-only log inspection
+- MLflow metric queries
+- Updating the manifest file
+- `sky jobs cancel <id>` — ONLY for provably wasted money
+
+**BANNED:** `sky exec`, code edits, Docker rebuilds, SSH.
+
+## Terminal State Detection
+
+A job is terminal when its status is one of:
+`SUCCEEDED`, `FAILED`, `FAILED_SETUP`, `CANCELLED`
+
+Continue polling until ALL jobs are terminal.
+
+## Kill-Switch (Rule F1 Exception)
+
+If 3+ jobs fail with IDENTICAL error within 5 minutes:
+1. Identify which remaining running jobs share the same configuration
+2. Cancel those jobs: `sky jobs cancel <id>`
+3. Let jobs with DIFFERENT configurations continue
+4. Transition immediately to DIAGNOSE phase with available failures
+
+## On Each New Failure
+
+When a job transitions to FAILED/FAILED_SETUP:
+1. Fetch logs: `sky jobs logs <job_id> --no-follow`
+2. Run `ralph_monitor.analyze_logs(logs, status)` for preliminary categorization
+3. Store the FailureInfo in the manifest entry for that job
+4. Do NOT start fixing — continue monitoring other jobs
+
+## Transition to DIAGNOSE
+
+When ALL jobs are terminal (or kill-switch activated), transition to DIAGNOSE.

--- a/.claude/skills/factorial-monitor/protocols/relaunch.md
+++ b/.claude/skills/factorial-monitor/protocols/relaunch.md
@@ -1,0 +1,51 @@
+# Protocol: Relaunch
+
+## Prerequisites
+
+- All fixes committed and verified (Rule F3)
+- Docker image rebuilt and pushed
+- Manifest updated with fix information
+
+## Selective Re-Launch (Rule F4)
+
+Re-launch ONLY the failed conditions. Never re-launch the entire grid.
+
+1. **Extract failed conditions from manifest:**
+   Filter jobs where `status` is FAILED/FAILED_SETUP and `relaunch_batch < 2`.
+
+2. **Generate re-launch commands:**
+   For each failed condition, construct the `sky jobs launch` command with
+   the same parameters as the original launch.
+
+3. **Update manifest:**
+   - Increment `relaunch_batch` for each re-launched condition
+   - Reset `status` to `STARTING`
+   - Record new `job_id` from SkyPilot
+
+4. **Return to MONITOR phase.**
+
+## Cycle Budget (Rule F4)
+
+| Cycle | What Happens |
+|-------|-------------|
+| 0 (original) | Full factorial launch |
+| 1 (first retry) | Re-launch only failed conditions from cycle 0 |
+| 2 (second retry) | Re-launch only failed conditions from cycle 1 |
+| 3+ | **HARD STOP** — escalate to user |
+
+After cycle 2, if failures persist:
+- Do NOT attempt cycle 3 without explicit user authorization
+- Present the full diagnostic report (see protocols/report.md)
+- Recommend specific next steps:
+  - "Root cause X persists despite fix — likely a deeper issue in Y"
+  - "Estimated cost for cycle 3: $Z — authorize?"
+
+## Cost Tracking
+
+Update manifest with cumulative cost after each cycle:
+```
+Cycle 0: 24 jobs × 0.7 hr × $1.30/hr = $21.84
+Cycle 1:  6 jobs × 0.5 hr × $1.30/hr =  $3.90
+Cycle 2:  2 jobs × 0.5 hr × $1.30/hr =  $1.30
+Total: $27.04
+```

--- a/.claude/skills/factorial-monitor/protocols/report.md
+++ b/.claude/skills/factorial-monitor/protocols/report.md
@@ -1,0 +1,70 @@
+# Protocol: Report
+
+## When to Generate
+
+- All jobs SUCCEEDED (happy path)
+- Max cycles exhausted (Rule F4)
+- User requests early termination
+
+## Report Structure
+
+```
+═══════════════════════════════════════════════════════════
+  FACTORIAL EXPERIMENT REPORT
+  Experiment: experiment_2026-03-19_debug
+  Config: configs/experiment/debug_factorial.yaml
+═══════════════════════════════════════════════════════════
+
+RESULTS
+  Total conditions: 24
+  Succeeded: 22 (91.7%)
+  Failed: 2 (8.3%)
+  Fix-relaunch cycles: 1
+
+COST
+  Cycle 0: $21.84 (24 jobs)
+  Cycle 1:  $3.90 (6 jobs)
+  Total:   $25.74
+
+FACTORIAL GRID
+  ┌─────────┬──────────┬──────────┬──────────┐
+  │         │ fold-0   │ fold-1   │ fold-2   │
+  ├─────────┼──────────┼──────────┼──────────┤
+  │ dice_ce │ ✓ dynunet│ ✓ dynunet│ ✓ dynunet│
+  │         │ ✓ sam3   │ ✓ sam3   │ ✗ sam3   │
+  ├─────────┼──────────┼──────────┼──────────┤
+  │ cbdice  │ ✓ dynunet│ ✓ dynunet│ ✓ dynunet│
+  │         │ ✓ sam3   │ ✓ sam3   │ ✗ sam3   │
+  └─────────┴──────────┴──────────┴──────────┘
+
+FAILURES (if any)
+  Root cause: OOM (2 jobs, sam3 × fold-2)
+  Fix attempted: Reduced patch_size to 96
+  Result: Still failing — SAM3 + fold-2 exceeds L4 VRAM
+  Recommendation: Use A100 for SAM3 fold-2 or reduce val set
+
+ISSUES CREATED
+  #873: SAM3 fold-2 OOM on L4 — requires A100 or patch reduction
+
+═══════════════════════════════════════════════════════════
+```
+
+## Output Files
+
+Save to `outputs/factorial_run_<experiment_id>.jsonl`:
+- One JSON object per job with all manifest fields
+- Aggregated summary as last line
+
+## GitHub Issues
+
+For each UNRECOVERABLE failure after max cycles:
+- compose_with: issue-creator
+- Include: root cause, affected conditions, fixes attempted, cost incurred
+- Link to the manifest file and relevant logs
+
+## MLflow Integration
+
+If jobs logged to MLflow, include:
+- Experiment name and run IDs for all succeeded jobs
+- Comparison table of key metrics (loss, dice score) across conditions
+- Link to MLflow UI for detailed analysis

--- a/.claude/skills/factorial-monitor/templates/factorial-manifest.json
+++ b/.claude/skills/factorial-monitor/templates/factorial-manifest.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "Factorial experiment manifest — single source of truth for experiment state",
+  "experiment_id": "experiment_2026-03-19_debug",
+  "config_file": "configs/experiment/debug_factorial.yaml",
+  "created_at": "2026-03-19T14:00:00+00:00",
+  "factors": {
+    "model_family": ["dynunet", "sam3_vanilla"],
+    "loss_name": ["dice_ce", "cbdice_cldice"],
+    "aux_calib": [false],
+    "fold": [0, 1, 2]
+  },
+  "skypilot_yaml": "deployment/skypilot/train_factorial.yaml",
+  "docker_image": "europe-north1-docker.pkg.dev/minivess-mlops/minivess/base:latest",
+  "docker_digest": "sha256:abc123...",
+  "max_relaunch_cycles": 2,
+  "current_cycle": 0,
+  "total_estimated_cost": 0.0,
+  "jobs": [
+    {
+      "condition": "dynunet/dice_ce/fold-0",
+      "model_family": "dynunet",
+      "loss_name": "dice_ce",
+      "aux_calib": false,
+      "fold": 0,
+      "job_id": null,
+      "status": "PENDING",
+      "start_time": null,
+      "end_time": null,
+      "duration_seconds": null,
+      "cost_usd": null,
+      "mlflow_run_id": null,
+      "failure_category": null,
+      "failure_root_cause": null,
+      "relaunch_batch": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- New skill `factorial-monitor` that orchestrates multi-job factorial experiments on SkyPilot
- Composes `ralph-loop` (per-job diagnosis) with `self-learning-iterative-coder` (batch code fixes)
- Born-upgraded with canonical folder structure from the skills upgrade plan (PR #872)
- 5 non-negotiable rules (F1-F5) preventing 9 known anti-patterns from metalearning history

## Architecture

```
factorial-monitor/
  SKILL.md                              # Orchestrator (6-phase workflow)
  instructions/rules.md                 # F1-F5 rules with rationale
  protocols/{launch,monitor,diagnose,fix,relaunch,report}.md
  eval/checklist.md                     # 5 binary criteria
  templates/factorial-manifest.json     # Experiment state schema
```

**6-phase workflow:** LAUNCH → MONITOR (read-only polling) → DIAGNOSE (batch aggregation) → FIX (reviewer-backed) → RELAUNCH (selective, max 2 cycles) → REPORT

**Key rules:**
- F1: No diagnosis until ALL jobs are terminal (prevents panic fixing)
- F2: Aggregate ALL failures before ANY fix (prevents whac-a-mole)
- F3: Docker rebuild mandatory before every re-launch (prevents stale image waste)
- F4: Max 2 fix-relaunch cycles (prevents cost overrun)
- F5: Factorial manifest = single source of truth (prevents partial amnesia)

## Test plan
- [x] Pre-commit hooks pass
- [x] Skill detected in system (visible in skill listing with correct description)
- [x] Negative triggers defined (not ralph-loop, not TDD, not overnight-runner)
- [ ] First real use: debug factorial experiment run

🤖 Generated with [Claude Code](https://claude.com/claude-code)